### PR TITLE
product: move BUGZILLA_STATES to product module

### DIFF
--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -95,6 +95,19 @@ options:
 '''
 
 
+BUGZILLA_STATES = set([
+    'ASSIGNED',
+    'CLOSED',
+    'MODIFIED',
+    'NEW',
+    'ON_DEV',
+    'ON_QA',
+    'POST',
+    'RELEASE_PENDING',
+    'VERIFIED',
+])
+
+
 class InvalidInputError(Exception):
     """ Invalid user input for a parameter """
     def __init__(self, param, value):
@@ -110,7 +123,7 @@ def validate_params(module, params):
     parameter.
     """
     for state in params['valid_bug_states']:
-        if state not in common_errata_tool.BUGZILLA_STATES:
+        if state not in BUGZILLA_STATES:
             raise InvalidInputError('valid_bug_states', state)
     solution = params['default_solution'].upper()
     try:

--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -173,19 +173,6 @@ class WorkflowRulesScraper(object):
         return results
 
 
-BUGZILLA_STATES = set([
-    'ASSIGNED',
-    'CLOSED',
-    'MODIFIED',
-    'NEW',
-    'ON_DEV',
-    'ON_QA',
-    'POST',
-    'RELEASE_PENDING',
-    'VERIFIED',
-])
-
-
 class DefaultSolutions(IntEnum):
     """
     Again, the reason we track ID mappings is because the HTML

--- a/tests/test_common_errata_tool.py
+++ b/tests/test_common_errata_tool.py
@@ -1,26 +1,10 @@
 import pytest
 from requests.exceptions import HTTPError
-from ansible.module_utils.common_errata_tool import BUGZILLA_STATES
 from ansible.module_utils.common_errata_tool import RELEASE_TYPES
 from ansible.module_utils.common_errata_tool import DefaultSolutions
 from ansible.module_utils.common_errata_tool import diff_settings
 from ansible.module_utils.common_errata_tool import describe_changes
 from ansible.module_utils.common_errata_tool import user_id
-
-
-def test_bugzilla_states():
-    expected = set([
-        'ASSIGNED',
-        'CLOSED',
-        'MODIFIED',
-        'NEW',
-        'ON_DEV',
-        'ON_QA',
-        'POST',
-        'RELEASE_PENDING',
-        'VERIFIED',
-    ])
-    assert BUGZILLA_STATES == expected
 
 
 @pytest.mark.parametrize("name,expected", [

--- a/tests/test_errata_tool_product.py
+++ b/tests/test_errata_tool_product.py
@@ -1,3 +1,4 @@
+from errata_tool_product import BUGZILLA_STATES
 from errata_tool_product import get_product
 
 
@@ -72,6 +73,21 @@ PRODUCT = {
         }
     }
 }
+
+
+def test_bugzilla_states():
+    expected = set([
+        'ASSIGNED',
+        'CLOSED',
+        'MODIFIED',
+        'NEW',
+        'ON_DEV',
+        'ON_QA',
+        'POST',
+        'RELEASE_PENDING',
+        'VERIFIED',
+    ])
+    assert BUGZILLA_STATES == expected
 
 
 class TestGetCdnRepo(object):


### PR DESCRIPTION
The `errata_tool_product` module is the only module that needs this list, so it makes sense to store this directly in the `errata_tool_product` module instead of storing it in `common_errata_tool`.