### PR TITLE
tests: fix test class name for get_product

### DIFF
--- a/tests/test_errata_tool_product.py
+++ b/tests/test_errata_tool_product.py
@@ -90,7 +90,7 @@ def test_bugzilla_states():
     assert BUGZILLA_STATES == expected
 
 
-class TestGetCdnRepo(object):
+class TestGetProduct(object):
 
     def test_not_found(self, client):
         client.adapter.register_uri(


### PR DESCRIPTION
This was a bad copy-and-paste from another test.