### PR TITLE
README: program_manager must be a login_name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Errata Tool.
         enabled: true
         active: true
         enable_batching: false
-        program_manager: anharris
+        program_manager: coolmanager@redhat.com
         blocker_flags:
         - ceph-4
         internal_target_release: ""


### PR DESCRIPTION
The GET REST API returns `program_manager`'s `login_name`. Users must specify the `login_name` so that these values line up.