### PR TITLE
common: add Client.delete() method

### DIFF
--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -264,6 +264,10 @@ class Client(object):
         if auth == 'kerberos':
             self.session.auth = HTTPSPNEGOAuth(opportunistic_auth=True)
 
+    def delete(self, endpoint, **kwargs):
+        url = posixpath.join(self.baseurl, endpoint)
+        return self.session.delete(url, **kwargs)
+
     def get(self, endpoint, **kwargs):
         url = posixpath.join(self.baseurl, endpoint)
         return self.session.get(url, **kwargs)

--- a/tests/test_common_errata_tool.py
+++ b/tests/test_common_errata_tool.py
@@ -102,3 +102,11 @@ class TestClient(object):
         method = getattr(client, verb)
         response = method('api/v1/foobar', json={'mykey': 'myval'})
         assert response.request.body == b'{"mykey": "myval"}'
+
+    def test_delete(self, client):
+        client.adapter.register_uri(
+            'DELETE',
+            'https://errata.devel.redhat.com/api/v1/foobar',
+            status_code=204)
+        response = client.delete('api/v1/foobar')
+        assert response.request.method == 'DELETE'


### PR DESCRIPTION
We will use this in the upcoming `errata_tool_cdn_repo` module, like:

```
DELETE /api/v1/cdn_repo_package_tags/{id}
```