### PR TITLE
common: disable mutual authentication

### DIFF
--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -4,7 +4,7 @@ import re
 from enum import IntEnum
 import posixpath
 import requests
-from requests_gssapi import HTTPSPNEGOAuth
+from requests_gssapi import HTTPSPNEGOAuth, DISABLED
 
 
 class PushTargetScraper(object):
@@ -262,7 +262,8 @@ class Client(object):
         self.session = requests.Session()
         auth = os.getenv('ERRATA_TOOL_AUTH', 'kerberos')
         if auth == 'kerberos':
-            self.session.auth = HTTPSPNEGOAuth(opportunistic_auth=True)
+            self.session.auth = HTTPSPNEGOAuth(opportunistic_auth=True,
+                                               mutual_authentication=DISABLED)
 
     def delete(self, endpoint, **kwargs):
         url = posixpath.join(self.baseurl, endpoint)


### PR DESCRIPTION
The ET Apache server has many problems with mutual authentication.  Disable all verifications of the GSSAPI mutual auth responses.