### PR TITLE
release: remove "default=None" from argspec

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -340,8 +340,8 @@ def run_module():
         allow_pkg_dupes=dict(type='bool', required=True),
         supports_component_acl=dict(type='bool', required=True),
         limit_bugs_by_product=dict(type='bool', required=True),
-        state_machine_rule_set=dict(default=None),
-        pelc_product_version_name=dict(default=None),
+        state_machine_rule_set=dict(),
+        pelc_product_version_name=dict(),
         brew_tags=dict(type='list', default=[]),
     )
     module = AnsibleModule(


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec says "When not specified, the default value is `None`"

We can omit "`default=None`" and rely on the default AnsibleModule behavior here.