### PR TITLE
mergify: update for Travis CI Application transition

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,8 +2,8 @@ pull_request_rules:
   - name: automatic merge for master when CI passes
     conditions:
       - author=ktdreyer
-      - status-success=continuous-integration/travis-ci/pr
-      - status-success=continuous-integration/travis-ci/push
+      - status-success=Travis CI - Pull Request
+      - status-success=Travis CI - Branch
       - base=master
     actions:
       merge:


### PR DESCRIPTION
I migrated errata-tool-ansible from travis-ci.org to travis-ci.com today, because the older travis-ci.org system used GitHub's legacy services integration, and today I encountered a problem where travis-ci.org fails to report PR build status back to GitHub.

After that transition to Travis CI's new "Application", the status reports names are different now. Mergify needs to respect the newer status report names.