### PR TITLE
tox.ini: add py37

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, flake8
+envlist = py27, py36, py37, flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
We were already testing py37 in Travis CI. Update tox.ini to match what we are testing in Travis CI, so that developers will easily run the same test matrix locally.