### PR TITLE
.stickler.yml: run flake8 with Python 3

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,5 +1,6 @@
 linters:
   flake8:
     fixer: true
+    python: 3
 fixers:
   enable: true


### PR DESCRIPTION
We mainly care about Python 3 nowdays, and Stickler CI defaults to Python 2.

Run the Stickler CI flake8 tests within a Python 3 environment.