### PR TITLE
variant: raise response.text contents on 403 error

### DIFF
--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -214,6 +214,11 @@ def handle_form_errors(response):
     if 'errorExplanation' in response.text:
         errors = scrape_error_explanation(response)
         raise RuntimeError(errors)
+    if response.status_code == 403:
+        # Possibly a lack of permissions (eg. setting the CPE text).
+        # Not sure what exactly to screen-scrape here, so we'll raise the
+        # whole response body for logging for now.
+        raise RuntimeError(response.text)
     response.raise_for_status()
 
 


### PR DESCRIPTION
When we receive an HTTP 403 error from the HTML form, there is very little information about what went wrong.

Return the entire HTML page. This will bloat the logs, but it will provide us more information.

A future improvement would be to look at a log file where we hit this code path, and then determine exactly what HTML values (error message) to screen-scrape here, and then only raise that exact error message, like we do elsewhere in `handle_form_errors()`.

A better improvement would be to have a proper REST API for variants (ERRATA-9718) so we have an official, documented way to handle errors.