### PR TITLE
doc: improve docs for product_version and variant push_targets

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -86,6 +86,8 @@ options:
        - One or more push targets (specify a list)
        - See /developer-guide/push-push-targets-options-and-tasks.html
          for more explanation about these push targets.
+       - This list must be a subset of the push targets that are set at the
+         parent product level.
      choices: [rhn_live, rhn_stage, ftp, cdn, cdn_stage, altsrc, cdn_docker,
                cdn_docker_stage]
      required: true

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -60,7 +60,7 @@ options:
          for more explanation about these push targets.
        - This list must be a subset of the push targets that are set at the
          parent product version level.
-     choices: [rhn_live, rhn_stage, ftp, cdn, cdn_stage, altsrc, cdn_docker,
+     choices: [rhn_live, rhn_stage, cdn, cdn_stage, altsrc, cdn_docker,
                cdn_docker_stage]
      required: true
 '''

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -58,8 +58,8 @@ options:
        - One or more push targets (specify a list)
        - See /developer-guide/push-push-targets-options-and-tasks.html
          for more explanation about these push targets.
-       - Leave this as an empty list in order to inherit the push targets from
-         the parent product or product_version.
+       - This list must be a subset of the push targets that are set at the
+         parent product version level.
      choices: [rhn_live, rhn_stage, ftp, cdn, cdn_stage, altsrc, cdn_docker,
                cdn_docker_stage]
      required: true


### PR DESCRIPTION
1) The push targets must be set on the parent object (product or product_version) first. Mention this in the docs.

2) A variant does not inherit push targets from the parent if they are unset. Correct this erronous statement.

3) "ftp" is not a valid push target for variants. Remove this from the docs.