### PR TITLE
variant: update scrape_error_explanation() method

### DIFF
--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -182,8 +182,8 @@ def scrape_error_explanation(response):
     """
     content = response.text
     doc = html.document_fromstring(content)
-    lis = doc.xpath('//div[@class="errorExplanation"]/li')
-    errors = [li.text_content.strip() for li in lis]
+    lis = doc.xpath('//div[@class="errorExplanation"]//li/text()')
+    errors = [li.strip() for li in lis]
     return errors
 
 

--- a/tests/test_errata_tool_variant.py
+++ b/tests/test_errata_tool_variant.py
@@ -1,5 +1,18 @@
-import errata_tool_variant
+from errata_tool_variant import scrape_error_explanation
 
 
-def test_simple():
-    assert errata_tool_variant
+class FakeErrorResponse(object):
+    pass
+
+
+def test_scrape_error_explanation():
+    response = FakeErrorResponse()
+    response.text = '''
+    <div id="errorExplanation" class="errorExplanation">
+    <h2>1 error prohibited this variant from being saved</h2>
+    <p>There were problems with the following fields:</p>
+    <ul><li>Variant push targets is invalid</li></ul></div>
+'''
+    result = scrape_error_explanation(response)
+    expected = ['Variant push targets is invalid']
+    assert result == expected


### PR DESCRIPTION
Fix the failure to scrape the error messages in `errata_tool_variant.py`'s
`scrape_error_explanation()` method.

Add a unit test to verify the correct behavior.