### PR TITLE
release: make several fields optional

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -125,8 +125,11 @@ options:
      default: false
      required: false
    limit_bugs_by_product:
+     description:
+       - Only relevant for QuarterlyUpdate releases.
      choices: [true, false]
-     required: true
+     default: false
+     required: false
    state_machine_rule_set:
      description:
        - Workflow Rule Set
@@ -356,7 +359,7 @@ def run_module():
         allow_exception=dict(type='bool', default=False),
         allow_pkg_dupes=dict(type='bool', default=False),
         supports_component_acl=dict(type='bool', default=False),
-        limit_bugs_by_product=dict(type='bool', required=True),
+        limit_bugs_by_product=dict(type='bool', default=False),
         state_machine_rule_set=dict(),
         pelc_product_version_name=dict(),
         brew_tags=dict(type='list', default=[]),

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -103,8 +103,11 @@ options:
      default: false
      required: false
    allow_exception:
+     description:
+       - Only relevant for QuarterlyUpdate releases.
      choices: [true, false]
-     required: true
+     default: false
+     required: false
    allow_pkg_dupes:
      description:
        - Allow duplicate advisories for packages
@@ -346,7 +349,7 @@ def run_module():
         ship_date=dict(),
         allow_shadow=dict(type='bool', default=False),
         allow_blocker=dict(type='bool', default=False),
-        allow_exception=dict(type='bool', required=True),
+        allow_exception=dict(type='bool', default=False),
         allow_pkg_dupes=dict(type='bool', required=True),
         supports_component_acl=dict(type='bool', required=True),
         limit_bugs_by_product=dict(type='bool', required=True),

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -110,9 +110,11 @@ options:
      required: false
    allow_pkg_dupes:
      description:
-       - Allow duplicate advisories for packages
+       - Allow duplicate advisories for packages. Only relevant for
+         QuarterlyUpdate releases.
      choices: [true, false]
-     required: true
+     default: false
+     required: false
    supports_component_acl:
      description:
        - If true, every Bugzilla ticket's component must be on the Approved
@@ -350,7 +352,7 @@ def run_module():
         allow_shadow=dict(type='bool', default=False),
         allow_blocker=dict(type='bool', default=False),
         allow_exception=dict(type='bool', default=False),
-        allow_pkg_dupes=dict(type='bool', required=True),
+        allow_pkg_dupes=dict(type='bool', default=False),
         supports_component_acl=dict(type='bool', required=True),
         limit_bugs_by_product=dict(type='bool', required=True),
         state_machine_rule_set=dict(),

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -120,8 +120,10 @@ options:
        - If true, every Bugzilla ticket's component must be on the Approved
          Component List (true) for this release. If false, ET will not consult
          the Bugzilla Approved Component List for this release.
+       - Only relevant for QuarterlyUpdate releases.
      choices: [true, false]
-     required: true
+     default: false
+     required: false
    limit_bugs_by_product:
      choices: [true, false]
      required: true
@@ -353,7 +355,7 @@ def run_module():
         allow_blocker=dict(type='bool', default=False),
         allow_exception=dict(type='bool', default=False),
         allow_pkg_dupes=dict(type='bool', default=False),
-        supports_component_acl=dict(type='bool', required=True),
+        supports_component_acl=dict(type='bool', default=False),
         limit_bugs_by_product=dict(type='bool', required=True),
         state_machine_rule_set=dict(),
         pelc_product_version_name=dict(),

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -97,8 +97,11 @@ options:
      default: false
      required: false
    allow_blocker:
+     description:
+       - Only relevant for QuarterlyUpdate releases.
      choices: [true, false]
-     required: true
+     default: false
+     required: false
    allow_exception:
      choices: [true, false]
      required: true
@@ -342,7 +345,7 @@ def run_module():
         zstream_target_release=dict(),
         ship_date=dict(),
         allow_shadow=dict(type='bool', default=False),
-        allow_blocker=dict(type='bool', required=True),
+        allow_blocker=dict(type='bool', default=False),
         allow_exception=dict(type='bool', required=True),
         allow_pkg_dupes=dict(type='bool', required=True),
         supports_component_acl=dict(type='bool', required=True),

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -91,8 +91,11 @@ options:
      required: true for QuarterlyUpdate releases only, false for others
      default: null
    allow_shadow:
+     description:
+       - Only relevant for QuarterlyUpdate releases.
      choices: [true, false]
-     required: true
+     default: false
+     required: false
    allow_blocker:
      choices: [true, false]
      required: true
@@ -338,7 +341,7 @@ def run_module():
         internal_target_release=dict(),
         zstream_target_release=dict(),
         ship_date=dict(),
-        allow_shadow=dict(type='bool', required=True),
+        allow_shadow=dict(type='bool', default=False),
         allow_blocker=dict(type='bool', required=True),
         allow_exception=dict(type='bool', required=True),
         allow_pkg_dupes=dict(type='bool', required=True),

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -86,7 +86,10 @@ options:
        - Default ship date for new advisories. "YYYY-MM-DD"
        - Note that you cannot use YAML's native date type here. You must quote
          the date value so that YAML passes a string to Ansible.
-     required: true
+       - If the release is a QuarterlyUpdate release, ship_date is required.
+         If it is ZStream or Async, ship_date is not required.
+     required: true for QuarterlyUpdate releases only, false for others
+     default: null
    allow_shadow:
      choices: [true, false]
      required: true
@@ -200,7 +203,8 @@ def get_release(client, name):
     # The API returns a full timestamp "ship_date", but we only accept
     # "YYYY-MM-DD" in Ansible. "dateutil" would be more robust, but I'm trying
     # to keep the dependencies light for this initial implementation.
-    release['ship_date'] = release['ship_date'][:10]
+    if release['ship_date'] is not None:
+        release['ship_date'] = release['ship_date'][:10]
 
     return release
 
@@ -333,7 +337,7 @@ def run_module():
         blocker_flags=dict(type='list', default=[]),
         internal_target_release=dict(),
         zstream_target_release=dict(),
-        ship_date=dict(required=True),
+        ship_date=dict(),
         allow_shadow=dict(type='bool', required=True),
         allow_blocker=dict(type='bool', required=True),
         allow_exception=dict(type='bool', required=True),


### PR DESCRIPTION
1) `ship_date` is only required for `QuarterlyUpdate` releases. Mark this field as optional in Ansible.

2) The following are irrelevant for `Async` and `Zstream` releases:
   - `allow_shadow`
   - `allow_blocker`
   - `allow_exception`
   - `allow_pkg_dupes`
   - `supports_component_acl`
   - `limit_bugs_by_product`

   Mark these fields as optional in Ansible.