### PR TITLE
release: send product_version_ids in every PUT request

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -335,6 +335,18 @@ def ensure_release(client, params, check_mode):
         changes = common_errata_tool.describe_changes(differences)
         result['stdout_lines'].extend(changes)
         if not check_mode:
+            # ERRATA-9867: we must send product_version_ids in every request,
+            # or the server will reset the product versions to an empty list.
+            changing_product_versions = False
+            for difference in differences:
+                key, _, _ = difference
+                if key == 'product_versions':
+                    changing_product_versions = True
+                    break
+            if not changing_product_versions:
+                differences.append(('product_versions',
+                                    params['product_versions'],
+                                    params['product_versions']))
             edit_release(client, release['id'], differences)
     return result
 


### PR DESCRIPTION
If we do not send `product_version_ids` in every PUT request, the ET server will reset the product versions to an empty list.

We can revert this change when the fix for ERRATA-9867 is deployed to production.