### PR TITLE
variant: scrape error-text div for messages

### DIFF
--- a/tests/test_errata_tool_variant.py
+++ b/tests/test_errata_tool_variant.py
@@ -1,4 +1,5 @@
 from errata_tool_variant import scrape_error_explanation
+from errata_tool_variant import scrape_error_message
 
 
 class FakeErrorResponse(object):
@@ -15,4 +16,21 @@ def test_scrape_error_explanation():
 '''
     result = scrape_error_explanation(response)
     expected = ['Variant push targets is invalid']
+    assert result == expected
+
+
+def test_scrape_error_message():
+    response = FakeErrorResponse()
+    response.text = '''
+    <div class="site_message">
+    <div class="alert alert-error">
+    <img src="/images/icon_alert.gif"
+    style="vertical-align:middle;"/>&nbsp;<b>Error</b>
+    <div id="error-message" class="just_text pre-wrap">
+    You do not have permission to edit CPE, need a secalert role
+    </div></div>
+    </div>
+    '''
+    result = scrape_error_message(response)
+    expected = ['You do not have permission to edit CPE, need a secalert role']
     assert result == expected


### PR DESCRIPTION
When we get an HTTP 403 error response from submitting the "variant" HTML form, we need to screen-scrape a slightly different HTML `<div>` in order to determine the exact error message.