### PR TITLE
user: handle 404 errors

### DIFF
--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -1,3 +1,4 @@
+import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_errata_tool
 
@@ -51,6 +52,26 @@ options:
 '''
 
 
+def scrape_user_id(client, login_name):
+    """
+    Screen-scrape the user ID number for this account.
+
+    Sometimes we cannot load the user account by name, but it exists.
+    Delete this method when ERRATA-9723 is resolved in prod.
+    """
+    data = {'user[login_name]': login_name}
+    response = client.post('user/find_user', data=data, allow_redirects=False)
+    if response.status_code != 302:
+        return None
+    location = response.headers['Location']
+    # location is a URL like https://errata...com/user/3002859
+    m = re.search(r'\d+$', location)
+    if not m:
+        return None
+    user_id = m.group()
+    return int(user_id)
+
+
 def get_user(client, login_name):
     url = 'api/v1/user/%s' % login_name
     r = client.get(url)
@@ -58,6 +79,15 @@ def get_user(client, login_name):
         # We will get an HTTP 500 error if the user does not exist yet.
         # Delete this condition once ERRATA-9723 is resolved.
         return None
+    if r.status_code == 404:
+        # It's possible this user has already been created, but they have a
+        # newer Kerberos account, and the ET API endpoint does not process
+        # those (see ERRATA-9723). Hack: screen-scrape the UID and try again
+        # with the number instead.
+        user_id = scrape_user_id(client, login_name)
+        if not user_id:
+            return None
+        return get_user(client, user_id)
     if r.status_code == 400:
         data = r.json()
         errors = data.get('errors', {})


### PR DESCRIPTION
In some cases, we can get an HTTP 404 error for a user account.

When this happens, it's not clear if the user does not exist or if the server failed to process the user's esoteric login_name.

When we get a 404, try screen-scraping the "Find User" form to find the user ID before giving up.