### PR TITLE
Omit CPE diff printouts if no CPE included

### DIFF
--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -280,6 +280,9 @@ def ensure_variant(client, params, check_mode):
         if not check_mode:
             create_variant(client, params)
         return result
+    # Don't print a diff for CPE if it was omitted
+    if params['cpe'] is None:
+        params.pop('cpe')
     differences = common_errata_tool.diff_settings(variant, params)
     if differences:
         result['changed'] = True


### PR DESCRIPTION
In the case where no CPE is passed via playbook, the diff prints out
something like:

"changing cpe from cpe:/a:redhat:cpe:stuff::el to None"

This makes it look like the CPE will be overwritten rather
than just being skipped.