### PR TITLE
cdn_repo: gracefully handle no packages for a repo

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -199,8 +199,8 @@ def get_cdn_repo(client, name, cdn_repo_data=None):
     cdn_repo['variants'] = variants
 
     # packages (names only)
-    package_names = [package['name'] for package in
-                     cdn_repo_data['relationships']['packages']]
+    packages = cdn_repo_data['relationships'].get('packages', [])
+    package_names = [package['name'] for package in packages]
     cdn_repo['package_names'] = package_names
     return cdn_repo
 

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -307,6 +307,30 @@ class TestGetCdnRepo(object):
         }
         assert cdn_repo == expected
 
+    def test_no_packages(self, client):
+        cdn_repo = deepcopy(CDN_REPO)
+        del cdn_repo['relationships']['packages']
+        client.adapter.register_uri(
+            'GET',
+            PROD + '/api/v1/cdn_repos',
+            json={'data': [cdn_repo]})
+        name = 'redhat-rhceph-rhceph-4-rhel8'
+        cdn_repo = get_cdn_repo(client, name)
+        expected = {
+            'id': 11010,
+            'name': 'redhat-rhceph-rhceph-4-rhel8',
+            'release_type': 'Primary',
+            'use_for_tps': False,
+            'content_type': 'Docker',
+            'arch': 'multi',
+            'variants': [
+                '8Base-RHCEPH-4.0-Tools',
+                '8Base-RHCEPH-4.1-Tools',
+            ],
+            'package_names': []
+        }
+        assert cdn_repo == expected
+
 
 class TestGetPackageTags(object):
 


### PR DESCRIPTION
Prior to this change, if a CDN repository had no packages set, the HTTP API would not return a "packages" key under "relationships".  The `get_cdn_repo()` method would raise a `KeyError` because we unconditionally queried `"packages"`.

Gracefully handle the case where the API does not return any packages data. `get_cdn_repo()` will return an empty list of `package_names`.

Fixes: #38