### PR TITLE
cdn_repo: make packages parameter optional

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -56,13 +56,29 @@ options:
          Errata Tool will apply this package's tag to all variants. If the tag
          is a dict, the Errata Tool will apply the package's tag to the single
          variant that you specify in the dict.
-     required: true
+       - If you omit this parameter, Ansible will remove all the existing
+         packages from this repository. You should omit this parameter for
+         repositories that are not content_type: Docker.
+     required: false
+     default: {} (no packages)
 '''
 
 EXAMPLES = '''
 - name: create cdn repositories
   hosts: localhost
   tasks:
+
+  - name: Add rhceph-4-tools-for-rhel-8-x86_64-rpms cdn repo
+    errata_tool_cdn_repo:
+      name: redhat-rhceph-rhceph-4-rhel8
+      release_type: Primary
+      content_type: Binary
+      use_for_tps: True
+      arch: x86_64
+      variants:
+      - 8Base-RHCEPH-4.0-Tools
+      - 8Base-RHCEPH-4.1-Tools
+
   - name: Add redhat-rhceph-rhceph-4-rhel8 cdn repo
     errata_tool_cdn_repo:
       name: redhat-rhceph-rhceph-4-rhel8
@@ -525,7 +541,7 @@ def run_module():
         arch=dict(),
         use_for_tps=dict(type='bool', default=False),
         variants=dict(type='list', required=True),
-        packages=dict(type='dict', required=True),
+        packages=dict(type='dict', default={}),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -770,7 +770,7 @@ class TestMain(object):
         return fake
 
     @pytest.fixture
-    def module_args(self):
+    def container_module_args(self):
         return {
             'name': 'redhat-rhceph-rhceph-4-rhel8',
             'release_type': 'Primary',
@@ -787,8 +787,8 @@ class TestMain(object):
             ]},
         }
 
-    def test_simple(self, module_args):
-        set_module_args(module_args)
+    def test_simple_container(self, container_module_args):
+        set_module_args(container_module_args)
         with pytest.raises(AnsibleExitJson) as exit:
             main()
         result = exit.value.args[0]
@@ -800,20 +800,20 @@ class TestMain(object):
         ('Debuginfo', 'x86_64'),
         ('Source',    'x86_64'),
     ])
-    def test_default_arch(self, module_args, fake_ensure_cdn_repo,
+    def test_default_arch(self, container_module_args, fake_ensure_cdn_repo,
                           content_type, expected):
-        module_args['arch'] = None
-        module_args['content_type'] = content_type
-        set_module_args(module_args)
+        container_module_args['arch'] = None
+        container_module_args['content_type'] = content_type
+        set_module_args(container_module_args)
         with pytest.raises(AnsibleExitJson):
             main()
         _, _, params = fake_ensure_cdn_repo.args
         assert params['arch'] == expected
 
-    def test_docker_arch_fail(self, module_args):
-        module_args['content_type'] = 'Docker'
-        module_args['arch'] = 'x86_64'
-        set_module_args(module_args)
+    def test_docker_arch_fail(self, container_module_args):
+        container_module_args['content_type'] = 'Docker'
+        container_module_args['arch'] = 'x86_64'
+        set_module_args(container_module_args)
         with pytest.raises(AnsibleFailJson) as exit:
             main()
         result = exit.value.args[0]


### PR DESCRIPTION
CDN repositories that are not `content_type: Docker` should not have packages set.

Fixes: #44 