### PR TITLE
release: remove unused lxml.html and re imports

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -1,7 +1,5 @@
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_errata_tool
-from lxml import html
-import re
 
 
 ANSIBLE_METADATA = {


### PR DESCRIPTION
Fixes flake8 errors:

```
F401 'lxml.html' imported but unused
F401 're' imported but unused
```