### PR TITLE
document Python library dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,23 @@ Tool.
         - pm
 
 
+Python dependencies
+-------------------
+
+These Ansible modules require the `requests-gssapi
+<https://pypi.org/project/requests-gssapi/>`_ and `lxml
+<https://pypi.org/project/lxml/>`_ Python libraries. You must install these
+libraries on the host where Ansible will execute (typically localhost).
+
+On RHEL 7::
+
+    yum -y install python-requests-gssapi python-lxml
+
+On RHEL 8 and Fedora::
+
+    yum -y install python3-requests-gssapi python3-lxml
+
+
 Errata Tool environment
 -----------------------
 These modules operate on the production Errata Tool environment by default.

--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -61,6 +61,10 @@ options:
          repositories that are not content_type: Docker.
      required: false
      default: {} (no packages)
+requirements:
+  - "python >= 2.7"
+  - "lxml"
+  - "requests-gssapi"
 '''
 
 EXAMPLES = '''

--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -92,6 +92,10 @@ options:
    text_only_advisories_require_dists:
      choices: [true, false]
      default: true
+requirements:
+  - "python >= 2.7"
+  - "lxml"
+  - "requests-gssapi"
 '''
 
 

--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -101,6 +101,10 @@ options:
        - What are the consequences of a completely empty brew_tag list? This
          might be answered in ERRATA-9713.
      required: true
+requirements:
+  - "python >= 2.7"
+  - "lxml"
+  - "requests-gssapi"
 '''
 
 

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -150,6 +150,10 @@ options:
        - Set to an empty list "[]" to simply inherit the brew_tags
          configuration from this release's ... Product Versions?.
      required: true
+requirements:
+  - "python >= 2.7"
+  - "lxml"
+  - "requests-gssapi"
 '''
 
 

--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -49,6 +49,10 @@ options:
      description:
        - A list of roles for this user, for example ["pm"]
      required: false
+requirements:
+  - "python >= 2.7"
+  - "lxml"
+  - "requests-gssapi"
 '''
 
 

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -63,6 +63,10 @@ options:
      choices: [rhn_live, rhn_stage, cdn, cdn_stage, altsrc, cdn_docker,
                cdn_docker_stage]
      required: true
+requirements:
+  - "python >= 2.7"
+  - "lxml"
+  - "requests-gssapi"
 '''
 
 


### PR DESCRIPTION
Document that we depend on `requests-gssapi` and `lxml` in each module's inline docs. I'm adding `lxml` to every module's documentation, even though every module does not use `lxml`, because `common_errata_tool` requires it.

Document how to install `requests-gssapi` and `lxml` in the `README`.

Fixes: #47 