### PR TITLE
cdn_repo: fix get_cdn_repo() docstring for cdn_repo_data

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -230,7 +230,8 @@ def get_cdn_repo(client, name, cdn_repo_data=None):
 
     :param client: Errata Client
     :param str name: CDN Repository name
-    :param dict name: cdn_repo_data (eg. from an earlier POST response)
+    :param dict cdn_repo_data: data about this CDN repository (eg. from an
+                               earlier POST response).
     :returns: dict of information about this CDN repository
     """
     if cdn_repo_data is None:


### PR DESCRIPTION
Fix a bad copy & paste for the `cdn_repo_data` parameter docstring.