### PR TITLE
release: rm non-bool value in ship_date docs

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -86,7 +86,6 @@ options:
          the date value so that YAML passes a string to Ansible.
        - If the release is a QuarterlyUpdate release, ship_date is required.
          If it is ZStream or Async, ship_date is not required.
-     required: true for QuarterlyUpdate releases only, false for others
      default: null
    allow_shadow:
      description:


### PR DESCRIPTION
ansible-doc fails to parse the inline documentation for this module if we do not specify a simple boolean "true" or "false" here.

Simply remove the line, because the value is required in the QuarterlyUpdate case, but not in the ZStream or Async cases.