### PR TITLE
fix YAML syntax in documentation

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -30,7 +30,7 @@ options:
      required: true
    content_type:
      description:
-       - "Binary" for RPMs, "Docker" for containers.
+       - '"Binary" for RPMs, "Docker" for containers.'
      choices: [Binary, Debuginfo, Source, Docker]
      required: true
    variants:
@@ -42,7 +42,7 @@ options:
        - The architecture for this CDN repo. You can only set this for
          non-Docker (ie RPM) repos. Docker will always be "multi".
      choices: [i386, ia64, s390, x86_64, s390x, ppc, ppc64, aarch64, ppc64le]
-     default: "x86_64" for RPMs, "multi" for Docker.
+     default: '"x86_64" for RPMs, "multi" for Docker.'
    use_for_tps:
      description:
        - Use TPS for Scheduling
@@ -56,11 +56,11 @@ options:
          Errata Tool will apply this package's tag to all variants. If the tag
          is a dict, the Errata Tool will apply the package's tag to the single
          variant that you specify in the dict.
-       - If you omit this parameter, Ansible will remove all the existing
+       - "If you omit this parameter, Ansible will remove all the existing
          packages from this repository. You should omit this parameter for
-         repositories that are not content_type: Docker.
+         repositories that are not content_type: Docker."
      required: false
-     default: {} (no packages)
+     default: "{} (no packages)"
 requirements:
   - "python >= 2.7"
   - "lxml"

--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -21,19 +21,19 @@ description:
 options:
    short_name:
      description:
-       - example: RHCEPH
+       - "example: RHCEPH"
      required: true
    name:
      description:
-       - example: Red Hat Ceph Storage
+       - "example: Red Hat Ceph Storage"
      required: true
    description:
      description:
-       - example: Red Hat Ceph Storage
+       - "example: Red Hat Ceph Storage"
      required: true
    bugzilla_product:
      description:
-       - example: null
+       - "example: null"
      required: false
    bugzilla_states:
      description:
@@ -47,11 +47,11 @@ options:
      default: true
    ftp_path:
      description:
-       - example: null
+       - "example: null"
      default: false
    ftp_subdir:
      description:
-       - example: RHCEPH
+       - "example: RHCEPH"
      default: false
    internal:
      description:
@@ -79,14 +79,14 @@ options:
    state_machine_rule_set:
      description:
        - Workflow Rule Set
-     choices: See https://errata.devel.redhat.com/workflow_rules
+     choices: ["See https://errata.devel.redhat.com/workflow_rules"]
      required: true
    move_bugs_on_qe:
      description:
-       - "true" means: move the bugs to ON_QA when the advisory moves to QE
-         state.
-       - "false" means: move the bugs to ON_QA as soon as the bugs are
-         attached to the advisory.
+       - '"true" means: move the bugs to ON_QA when the advisory moves to QE
+         state.'
+       - '"false" means: move the bugs to ON_QA as soon as the bugs are
+         attached to the advisory.'
      choices: [true, false]
      default: false
    text_only_advisories_require_dists:

--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -19,19 +19,20 @@ description:
 options:
    product:
      description:
-       - Product for this Product Version - example: RHCEPH
+       - Product for this Product Version
+       - "example: RHCEPH"
      required: true
    name:
      description:
-       - example: RHCEPH-4.0-RHEL-8
+       - "example: RHCEPH-4.0-RHEL-8"
      required: true
    description:
      description:
-       - example: Red Hat Ceph Storage 4.0
+       - "example: Red Hat Ceph Storage 4.0"
      required: true
    rhel_release_name:
      description:
-       - example: RHEL-8
+       - "example: RHEL-8"
      required: true
    sig_key_name:
      description:
@@ -45,7 +46,7 @@ options:
      description:
        - The default brew tag to use when validating that a build can be added
          to an advisory
-       - example: ceph-4.0-rhel-8-candidate
+       - "example: ceph-4.0-rhel-8-candidate"
        - You must specify this tag as one of the elements in the brew_tags
          list (see ERRATA-9713)
      required: true
@@ -61,8 +62,8 @@ options:
      default: true
    allow_rhn_debuginfo:
      description:
-       - "true" if -debuginfo rpms from this product version can be shipped to
-         RHN
+       - '"true" if -debuginfo rpms from this product version can be shipped to
+         RHN'
      choices: [true, false]
      required: true
    allow_buildroot_push:

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -19,21 +19,21 @@ description:
 options:
    product:
      description:
-       - example: RHCEPH
+       - "example: RHCEPH"
        - Async releases do not require a product.
      required: false
      default: null
    name:
      description:
-       - example: rhceph-4.0
+       - "example: rhceph-4.0"
      required: true
    description:
      description:
-       - example: Red Hat Ceph Storage 4.0
+       - "example: Red Hat Ceph Storage 4.0"
      required: true
    type:
      description:
-       - example: QuarterlyUpdate
+       - "example: QuarterlyUpdate"
      choices: [QuarterlyUpdate, Zstream, Async]
      required: true
    product_versions:
@@ -63,7 +63,7 @@ options:
    blocker_flags:
      description:
        - Bugzilla blocker flags (specify a list).
-       - Example: [ceph-3.0, devel_ack, qa_ack, pm_ack]
+       - "Example: [ceph-3.0, devel_ack, qa_ack, pm_ack]"
        - Optional for Async errata (or all advisories at this point?)
      required: false
      default: []

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -19,11 +19,11 @@ description:
 options:
    name:
      description:
-       - example: 8Base-RHCEPH-4.0-Tools
+       - "example: 8Base-RHCEPH-4.0-Tools"
      required: true
    description:
      description:
-       - example: Red Hat Ceph Storage 4.0 Tools
+       - "example: Red Hat Ceph Storage 4.0 Tools"
      required: true
    cpe:
      description:
@@ -31,7 +31,7 @@ options:
          permissions to configure the cpe text value. If you omit this value,
          Ansible will not set it during variant creation or edit it on an
          existing variant.
-       - example: "cpe:/a:redhat:ceph_storage:4::el8"
+       - "example: cpe:/a:redhat:ceph_storage:4::el8"
      required: false
    enabled:
      description:
@@ -46,11 +46,11 @@ options:
      default: false
    product_version:
      description:
-       - example: RHCEPH-4.0-RHEL-8
+       - "example: RHCEPH-4.0-RHEL-8"
      required: true
    rhel_variant:
      description:
-       - example: 8Base
+       - "example: 8Base"
        - I'm guessing that only Layered Products require this, so it should
          not really be mandatory, but I'm unfamiliar with how RHEL itself is
          configured in the Errata Tool.


### PR DESCRIPTION
Prior to this change, ansible-doc failed to parse the inline docs for the modules. Edit or quote lines that use ":" so that ansible-doc can parse these.