### PR TITLE
errata_tool_cdn_repo: handle reading pkgs with no tags

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -195,9 +195,11 @@ def get_package_tags(client, name):
     :returns: dict of "packages: tag_templates". Each tag_template is a dict.
               If it has a "variant" key, then it is restricted to a variant.
               If it has no "variant" key, there are no restrictions for this
-              repo's package's tag_template.
+              repo's package's tag_template. If a package in this repo has no
+              tags, you must discover it with get_cdn_repo(), because this API
+              will not return it.
     """
-    # We will query all the packages for this repo.
+    # We will query all the packages' tags for this repo.
     # Example for looking up one single package in one single repo:
     # https://errata.devel.redhat.com/api/v1/cdn_repo_package_tags?filter[package_name]=ubi8-container&filter[cdn_repo_name]=redhat-ubi8
     page_number = 0
@@ -479,7 +481,7 @@ def ensure_packages_tags(client, name, check_mode, packages):
     current = get_package_tags(client, name)
 
     for package_name in packages:
-        current_tags = current[package_name]
+        current_tags = current.get(package_name, [])
         desired_tags = packages[package_name]
 
         package_changes = ensure_package_tags(client,

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -578,6 +578,18 @@ class TestEnsurePackageTags(EnsurePackageTagsBase):
         assert len(client.adapter.request_history) == 2
         assert client.adapter.request_history[1].method == 'PUT'
 
+    def test_add_one_from_zero(self, client, name, check_mode):
+        client.adapter.register_uri(
+            'GET',
+            PROD + '/api/v1/cdn_repo_package_tags',
+            json={'data': []})
+        packages = {'rhceph-container': {'latest': {}}}
+        result = ensure_packages_tags(client, name, check_mode, packages)
+        expected = ['adding "latest" tag template to "rhceph-container"']
+        assert result == expected
+        assert len(client.adapter.request_history) == 2
+        assert client.adapter.request_history[1].method == 'POST'
+
 
 class TestEnsurePackageTagsCheckMode(EnsurePackageTagsBase):
     """


### PR DESCRIPTION
If a package in a repository has zero tags, `get_package_tags()` will not return any key for that package name at all. The reason is that the `/api/v1/cdn_repo_package_tags` API endpoint does not return any entries for packages with zero tags.

Prior to this change, the `ensure_packages_tags()` method could raise a `KeyError` when we try to compare the `current_tags` for a package with the `desired_tags`, because `current_tags` has no key for this `package_name`.

Update `ensure_package_tags()` to handle the missing `package_name` keys in the `current_tags` data we obtain from `get_package_tags()`.

Update the code comments to reflect the ET's behavior here, and add a unit test that verifies the ability to add a tag to a package that starts with zero tags.

Fixes: #72 