### PR TITLE
cdn_repo: log add_package_tag() request JSON on error

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -324,7 +324,8 @@ def add_package_tag(client, repo_name, package_name, tag_template, variant):
     response = client.post(endpoint, json=json)
     if response.status_code != 201:
         data = response.json()
-        raise ValueError(data['error'])
+        message = 'request: %s, error: %s' % (json, data['error'])
+        raise ValueError(message)
 
 
 def edit_package_tag(client, tag_id, desired_tag):

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -406,7 +406,12 @@ class TestAddPackageTag(object):
             json={'status': 400, 'error': 'Bad Request'})
         with pytest.raises(ValueError) as err:
             add_package_tag(client, '', '', 'latest', None)
-        assert str(err.value) == 'Bad Request'
+        request = {'cdn_repo_package_tag':
+                   {'cdn_repo_name': '',
+                    'package_name': '',
+                    'tag_template': 'latest'}}
+        expected = 'request: %s, error: Bad Request' % request
+        assert str(err.value) == expected
 
 
 class TestNormalize(object):


### PR DESCRIPTION
The Errata Tool validates new tag names with a regular expression, and sometimes it's hard to understand exactly which tag name string failed this validation.

Raise the entire request body (which includes the offending tag name) as well as the server error message.