### PR TITLE
improve documentation for escaping CDN repo tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,12 +153,12 @@ Errata Tool.
         packages:
           rhceph-container:
           - latest
-          - "{{ '{{' }}version{{ '}}' }}"
-          - "{{ '{{' }}version{{ '}}' }}-{{ '{{' }}release{{ '}}' }}"
+          - "{% raw %}{{version}}{% endraw %}"
+          - "{% raw %}{{version}}-{{release}}{% endraw %}"
 
 Note that if you want to use a tag string like ``{{version}}`` for your
-package, you must escape the double brackets for Ansible, like
-``"{{ '{{' }}version{{ '}}' }}"``.
+package, you must escape the double brackets for Ansible with the
+``{% raw %} ... {% endraw %}`` syntax.
 
 errata_tool_user
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,8 @@ Errata Tool.
 
 Note that if you want to use a tag string like ``{{version}}`` for your
 package, you must escape the double brackets for Ansible with the
-``{% raw %} ... {% endraw %}`` syntax.
+``{% raw %} ... {% endraw %}`` syntax. If you pass the values into Ansible
+Tower's REST API, you may not need to escape the values like this.
 
 errata_tool_user
 ----------------


### PR DESCRIPTION
The CDN repository tags are tricky to get right in Ansible. Add more instructions to the README about this.