### PR TITLE
Fix issue with missing organization for user

### DIFF
--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -148,6 +148,10 @@ def ensure_user(client, params, check_mode):
             create_user(client, params)
         return result
     user_id = user.pop('id')
+    # Don't print a diff for organization if it was omitted
+    if params['organization'] is None:
+        params.pop('organization')
+
     differences = common_errata_tool.diff_settings(user, params)
     if differences:
         result['changed'] = True


### PR DESCRIPTION
When there is no organization defined then it was detected change since
default org 'Engineering' does not match with None.
Fixed by not comparing organization when it's not in params.

Fixes #58