### PR TITLE
update Jira ticket references

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -237,7 +237,7 @@ def get_cdn_repo(client, name, cdn_repo_data=None):
     :returns: dict of information about this CDN repository
     """
     if cdn_repo_data is None:
-        # ERRATA-9728 to get cdn_repos directly by name.
+        # CLOUDWF-316 to get cdn_repos directly by name.
         response = client.get('api/v1/cdn_repos?filter[name]=%s' % name)
         response.raise_for_status()
         json = response.json()
@@ -529,7 +529,7 @@ def ensure_cdn_repo(client, check_mode, params):
         changes = common_errata_tool.describe_changes(differences)
         result['stdout_lines'].extend(changes)
         if not check_mode:
-            # ERRATA-9728 to access cdn_repos directly by name.
+            # CLOUDWF-316 to access cdn_repos directly by name.
             edit_cdn_repo(client, cdn_repo['id'], differences)
 
     # packages (from /api/v1/cdn_repo_package_tags):
@@ -569,7 +569,7 @@ def run_module():
             params['arch'] = 'x86_64'
 
     # The ET server does not stop users from setting Docker repos to other
-    # arches (ERRATA-9726). We will guard that here for now.
+    # arches (CLOUDWF-271). We will guard that here for now.
     if params['content_type'] == 'Docker' and params['arch'] != 'multi':
         module.fail_json(msg='arch must be "multi" for Docker repos')
 

--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -268,10 +268,10 @@ def handle_form_errors(response):
 
 
 def create_product(client, params):
-    """ See ERRATA-9706 for official create API """
+    """ See CLOUDWF-7 for official create API """
     data = html_form_data(client, params)
 
-    # Hack for ERRATA-9703:
+    # Hack for CLOUDWF-309:
     # If there are any push targets, then create the product *without* push
     # targets first, and then edit the product with the push targets.
     saved_push_targets = data.pop('product[push_targets][]')
@@ -279,7 +279,7 @@ def create_product(client, params):
     response = client.post('products', data=data)
     handle_form_errors(response)
 
-    # Hack for ERRATA-9703, part 2:
+    # Hack for CLOUDWF-309, part 2:
     # Edit product we just created so that we can set the push targets.
     if saved_push_targets:
         # Get the new product ID for the product we just created.
@@ -294,7 +294,7 @@ def edit_product(client, product_id, params):
     """
     Edit an existing product.
 
-    See ERRATA-9706 for official edit API.
+    See CLOUDWF-7 for official edit API.
 
     :param client: Errata Client
     :param int product_id: ID of the product we will edit

--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -48,7 +48,7 @@ options:
          to an advisory
        - "example: ceph-4.0-rhel-8-candidate"
        - You must specify this tag as one of the elements in the brew_tags
-         list (see ERRATA-9713)
+         list (see CLOUDWF-2)
      required: true
    is_server_only:
      description:
@@ -98,9 +98,9 @@ options:
          builds are tagged with this Brew tag in order to attach to an
          advisory.
        - You must specify the default_brew_tag as one of the elements
-         in this list (see ERRATA-9713)
+         in this list (see CLOUDWF-2)
        - What are the consequences of a completely empty brew_tag list? This
-         might be answered in ERRATA-9713.
+         might be answered in CLOUDWF-2.
      required: true
 requirements:
   - "python >= 2.7"
@@ -118,7 +118,7 @@ class InvalidInputError(Exception):
 
 def get_product_version(client, product, name):
     # We cannot query directly by name yet if the name as a "." character.
-    # See ERRATA-9712.
+    # See CLOUDWF-3.
     # url = 'api/v1/products/%s/product_versions/%s' % (product, name)
     # ... this would also change the returned data structure slightly (the
     # results would not be in a list.)
@@ -161,7 +161,7 @@ def set_push_targets(client, product, product_version, push_targets):
     """
     Set push targest through the web form.
 
-    This is a temporary hack until we have API support in ERRATA-9714
+    This is a temporary hack until we have API support in CLOUDWF-5
 
     :param str product: product name
     :param str product_version: product version name (or id)

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -176,7 +176,7 @@ def validate_params(module, params):
 
 
 def get_release(client, name):
-    # cannot get releases directly by name, ERRATA-9718
+    # cannot get releases directly by name, CLOUDWF-1
     r = client.get('api/v1/releases?filter[name]=%s' % name)
     r.raise_for_status()
     data = r.json()
@@ -256,7 +256,7 @@ def api_data(client, params):
     # Are those really a valid settings? grep errata-rails.git for more
     # references to find out. That whole POST /api/v1/releases section of the
     # docs could probably use a review.
-    # ERRATA-9719 is an RFE for specifying all values by name instead of ID.
+    # CLOUDWF-298 is an RFE for specifying all values by name instead of ID.
     release = params.copy()
     # Update the values for ones that the REST API will accept:
     if 'product' in release:
@@ -336,7 +336,7 @@ def ensure_release(client, params, check_mode):
         changes = common_errata_tool.describe_changes(differences)
         result['stdout_lines'].extend(changes)
         if not check_mode:
-            # ERRATA-9867: we must send product_version_ids in every request,
+            # CLOUDWF-6: we must send product_version_ids in every request,
             # or the server will reset the product versions to an empty list.
             changing_product_versions = False
             for difference in differences:

--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -61,7 +61,7 @@ def scrape_user_id(client, login_name):
     Screen-scrape the user ID number for this account.
 
     Sometimes we cannot load the user account by name, but it exists.
-    Delete this method when ERRATA-9723 is resolved in prod.
+    Delete this method when CLOUDWF-8 is resolved in prod.
     """
     data = {'user[login_name]': login_name}
     response = client.post('user/find_user', data=data, allow_redirects=False)
@@ -81,12 +81,12 @@ def get_user(client, login_name):
     r = client.get(url)
     if r.status_code == 500:
         # We will get an HTTP 500 error if the user does not exist yet.
-        # Delete this condition once ERRATA-9723 is resolved.
+        # Delete this condition once CLOUDWF-8 is resolved.
         return None
     if r.status_code == 404:
         # It's possible this user has already been created, but they have a
         # newer Kerberos account, and the ET API endpoint does not process
-        # those (see ERRATA-9723). Hack: screen-scrape the UID and try again
+        # those (see CLOUDWF-8). Hack: screen-scrape the UID and try again
         # with the number instead.
         user_id = scrape_user_id(client, login_name)
         if not user_id:

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -81,7 +81,7 @@ def get_variant(client, name):
     :param str name: Variant name to search
     :returns: dict of information about this variant, or None
     """
-    # We cannot get the name directly yet, ERRATA-9715
+    # We cannot get the name directly yet, CLOUDWF-4
     # r = client.get('api/v1/variants/%s' % name)
     r = client.get('api/v1/variants?filter[name]=%s' % name)
     r.raise_for_status()
@@ -96,7 +96,7 @@ def get_variant(client, name):
     variant['id'] = variant_data['id']
     # Unique to this variants API endpoint:
     # "relationships" are nested inside "attributes".
-    # API Doc fix at ERRATA-9716
+    # API Doc fix at CLOUDWF-308
     attributes = variant_data['attributes']
     variant.update(attributes)
     relationships = variant.pop('relationships')

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -126,8 +126,6 @@ def edit_variant(client, variant_id, differences):
     """
     Edit an existing variant.
 
-    See ERRATA-9717 for official edit API.
-
     :param client: Errata Client
     :param int variant_id: ID number for the variant
     :param list differences: changes to make

--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -16,7 +16,6 @@ class PushTargetScraper(object):
 
       products (ERRATA-9706)
       product_versions (ERRATA-9714)
-      variants (ERRATA-9717)
 
     See /developer-guide/push-push-targets-options-and-tasks.html for
     information about Push Targets. This class uses the same string names

--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -14,8 +14,8 @@ class PushTargetScraper(object):
     The ET server currently requires that we POST PushTarget ID integers
     instead of names. This applies to the following resources:
 
-      products (ERRATA-9706)
-      product_versions (ERRATA-9714)
+      products (CLOUDWF-7)
+      product_versions (CLOUDWF-5)
 
     See /developer-guide/push-push-targets-options-and-tasks.html for
     information about Push Targets. This class uses the same string names
@@ -118,8 +118,8 @@ class WorkflowRulesScraper(object):
     There are two endpoints that require us to send Workflow Rule ID numbers
     (ints) instead of names (human-readable strings):
 
-      POST to /products (see ERRATA-9706)
-      POST and PUT to /api/v1/releases (ERRATA-9719)
+      POST to /products (see CLOUDWF-7)
+      POST and PUT to /api/v1/releases (CLOUDWF-298)
 
     When we fix these, we will no longer need this WorkflowRulesScraper class.
     """
@@ -229,7 +229,7 @@ def user_id(client, login_name):
     """
     Convert a user login_name to an id
 
-    Needed for products (ERRATA-9706) and releases (ERRATA-9719)
+    Needed for products (CLOUDWF-7) and releases (CLOUDWF-298)
     """
     response = client.get('api/v1/user/%s' % login_name)
     if response.status_code == 400:

--- a/tests/test_common_errata_tool.py
+++ b/tests/test_common_errata_tool.py
@@ -58,9 +58,9 @@ class TestUserID(object):
         result = user_id(client, 'cooluser@redhat.com')
         assert result == 123456
 
-    def test_errors_pre_errata_9723(self, client):
-        # This test simulates the HTTP 500 error described in ERRATA-9723.
-        # Delete this test after ERRATA-9723 is resolved.
+    def test_errors_pre_cloudwf_8(self, client):
+        # This test simulates the HTTP 500 error described in CLOUDWF-8.
+        # Delete this test after CLOUDWF-8 is resolved.
         client.adapter.register_uri(
             'GET',
             'https://errata.devel.redhat.com/api/v1/user/noexist@redhat.com',
@@ -70,7 +70,7 @@ class TestUserID(object):
             user_id(client, 'noexist@redhat.com')
 
     def test_errors(self, client):
-        # This test simulates the expected HTTP 400 error after ERRATA-9723 is
+        # This test simulates the expected HTTP 400 error after CLOUDWF-8 is
         # resolved.
         json = {'errors': {'login_name': ['noexist@redhat.com not found.']}}
         client.adapter.register_uri(

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -25,7 +25,7 @@ from utils import AnsibleFailJson
 PROD = 'https://errata.devel.redhat.com'
 
 # From /api/v1/cdn_repos/?filter[name]=redhat-rhceph-rhceph-4-rhel8
-# See ERRATA-9728
+# See CLOUDWF-316
 CDN_REPO = {
     "id": 11010,
     "type": "cdn_repos",

--- a/tests/test_errata_tool_user.py
+++ b/tests/test_errata_tool_user.py
@@ -20,7 +20,7 @@ class TestGetUser(object):
 
     def test_not_found_http_500(self, client):
         # ET currently returns HTTP 500 for missing users.
-        # Delete this test when ERRATA-9723 is resolved.
+        # Delete this test when CLOUDWF-8 is resolved.
         client.adapter.register_uri(
             'GET',
             'https://errata.devel.redhat.com/api/v1/user/me@redhat.com',
@@ -31,7 +31,7 @@ class TestGetUser(object):
     def test_found_http_404(self, client):
         # ET currently returns HTTP 404 for users with some Kerberos realm
         # suffixes.
-        # Delete this test when ERRATA-9723 is resolved.
+        # Delete this test when CLOUDWF-8 is resolved.
         client.adapter.register_uri(
             'GET',
             'https://errata.devel.redhat.com/api/v1/user/me@IPA.REDHAT.COM',
@@ -51,7 +51,7 @@ class TestGetUser(object):
         assert user == USER
 
     def test_not_found(self, client):
-        # This test will match the ET server once ERRATA-9723 is resolved.
+        # This test will match the ET server once CLOUDWF-8 is resolved.
         client.adapter.register_uri(
             'GET',
             'https://errata.devel.redhat.com/api/v1/user/me@redhat.com',


### PR DESCRIPTION
The new variants REST API is live in production now, so ERRATA-9717 is resolved. I switched to this new API in commit 55a7133414f22a9ac26cf0dc2f29e0da0e9a4c45, but I forgot to drop the comments that still refer to that ticket.

All the old "ERRATA" tickets that are still open have moved to the CLOUDWF project in Jira. Update the comments to use the new ticket keys so they are easier to find and discuss.