### PR TITLE
product: fix bugzilla_product_name parameter docs

### DIFF
--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -31,7 +31,7 @@ options:
      description:
        - "example: Red Hat Ceph Storage"
      required: true
-   bugzilla_product:
+   bugzilla_product_name:
      description:
        - "example: null"
      required: false


### PR DESCRIPTION
The parameter is named "`bugzilla_product_name`". Update the inline docs to reflect this.