### PR TITLE
product: valid_bug_states fixes

### DIFF
--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -35,11 +35,12 @@ options:
      description:
        - "example: null"
      required: false
-   bugzilla_states:
+   valid_bug_states:
      description:
-       - Valid bug states
+       - A list of valid Bugzilla bug states
      choices: [NEW, ASSIGNED, ON_DEV, POST, MODIFIED, ON_QA, VERIFIED]
-     required: true
+     required: false
+     default: [MODIFIED, VERIFIED]
    active:
      description:
        - Is the product active for Errata filing?
@@ -332,7 +333,7 @@ def run_module():
         name=dict(required=True),
         description=dict(required=True),
         bugzilla_product_name=dict(default=''),
-        valid_bug_states=dict(type='list'),
+        valid_bug_states=dict(type='list', default=['MODIFIED', 'VERIFIED']),
         active=dict(type='bool', default=True),
         ftp_path=dict(default=""),
         ftp_subdir=dict(),


### PR DESCRIPTION
Update the inline docs to the correct parameter name: "`valid_bug_states`". Update the description to specify that this only applies to Bugzilla bugs.

Prior to this change, if a user omitted "`valid_bug_states`", the module would crash because it would try to iterate over None. Update the default value to be a list so we do not crash.

When we send an empty `valid_bug_states` list to the server, the server defaults to a value of "MODIFIED,VERIFIED". Duplicate this default behavior here. This will remove the spurious change message from `stdout_lines` when users omit this parameter. Also check mode correctly displays what would change when users omit the value.

Fixes: #77