### PR TITLE
tox: fix library path typo for flake8 env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]
 deps=flake8
-commands=flake8 --select=F,E9 {posargs:libary}
+commands=flake8 --select=F,E9 {posargs:library}


### PR DESCRIPTION
Prior to this change, the flake8 tox env failed, because I misspelled the `library` directory.