### PR TITLE
cdn_repos: fix TestEnsureCdnRepo docstring

### DIFF
--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -643,7 +643,7 @@ class TestEnsurePackageTagsCheckMode(EnsurePackageTagsBase):
 
 class TestEnsureCdnRepo(object):
     """
-    Assert ensure_package_tags() behavior with "check_mode=True".
+    Assert ensure_package_tags() behavior.
     """
 
     @pytest.fixture


### PR DESCRIPTION
Remove the comment about `check_mode=True`, because the tests in this class exercise both `True` and `False` values for `check_mode`.