### PR TITLE
user: receives_mail and email_address parameter improvements

### DIFF
--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -163,7 +163,7 @@ def ensure_user(client, params, check_mode):
     user_id = user.pop('id')
 
     # Do not change these settings if the playbook author omits them ("None").
-    for param in ('organization', 'roles'):
+    for param in ('organization', 'roles', 'email_address'):
         if params[param] is None:
             params.pop(param)
 

--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -43,8 +43,15 @@ options:
    email_address:
      description:
        - The email address for this user.
+       - If you do not set this parameter and the user does not yet exist,
+         Ansible will create the user by selecting the login_name string
+         before "@" and appending a redhat.com domain for an email address.
+         For example, if a new user's login_name is "kdreyer@redhat.com", the
+         default email_address will be "kdreyer@redhat.com".
+       - If you do not set this parameter and the user already exists on the
+         server, Ansible will not edit the existing email address for this
+         user account.
      required: false
-     default: The ET server chooses a default email address.
    roles:
      description:
        - A list of roles for this user, for example ["pm"]


### PR DESCRIPTION
This pull request changes the behavior of the `errata_tool_user` module in the following ways:

- Do not accidentally reset `receives_mail` to `false` (CLOUDWF-2817)

- Do not modify an existing user's email address if the playbook author omits the `email_address` parameter.

Fixes: #80