### PR TITLE
release: update doc description for program_manager

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -58,7 +58,8 @@ options:
      default: true
    program_manager:
      description:
-       - The program manager for this release (Kerberos username)
+       - The program manager for this release (login_name, eg
+         "coolprogrammanager@redhat.com")
      required: true
    blocker_flags:
      description:


### PR DESCRIPTION
The `program_manager` parameter should be the user account `login_name`, which may or may not be the Kerberos principal. Update the description for the `program_manager` field to reflect this, and give an example `login_name` with a lowercase "@redhat.com" suffix.