### PR TITLE
release: document default behavior for state_machine_rule_set

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -133,6 +133,9 @@ options:
        - Workflow Rule Set
        - Set to "null" to simply inherit the main workflow_rule_set
          configuration from this release's product.
+       - If you omit this parameter, Ansible will default to "null" and re-set
+         the release's workflow ruleset back to null (so, inheriting the
+         product's ruleset).
      choices: [default, unrestricted, cdn_push_only, covscan, rhel_7_beta,
                abidiff_pilot_deprecated, non_blocking_tps, covscan_deprecated,
                optional_tps_distqa, optional_stage_push_for_rhel_6_8,


### PR DESCRIPTION
This parameter behaves a little differently than other parameters when a playbook author omits it. Document what happens when omitting it.

Other parameters do not override values when unspecified, so this behavior is a little surprising. See `default_docs_reviewer` in `errata_tool_product.py` for an example of a parameter that behaves in the opposite way.

I'm preserving this behavior and documenting it instead of changing this now. My reason is that I want to be able to set rules back to "null" on releases. Generally speaking, it adds a lot of complexity to have per-release rules that override per-product rules. I'm thinking we should steer playbook authors toward simplifying their configurations instead of making them more complex.

Maybe in the future we can revisit this decision. The web UI HTML form has a dropdown with a string "(unset)" to represent a "null" value, and maybe we could do that in Ansible here. That does add complexity though, and I'm not sure if it's worth it.