### PR TITLE
tests: remove useless register_uri() from test_edit_variant

### DIFF
--- a/tests/test_errata_tool_variant.py
+++ b/tests/test_errata_tool_variant.py
@@ -59,10 +59,6 @@ class TestResponses(object):
 
     def test_edit_variant(self, client, params):
         client.adapter.register_uri(
-            'GET',
-            PROD + '/api/v1/variants?filter%5Bname%5D=8Base-RHCEPH-4.0-Tools',
-            json=ceph_tools_variant_json_response())
-        client.adapter.register_uri(
             'PUT',
             PROD + '/api/v1/variants/2341')
         # Very Cool Tools


### PR DESCRIPTION
The `edit_variant()` method does not make any GET requests, so we do not need to register a fake GET response. (This was likely a bad copy-and-paste from another test.)