### PR TITLE
product_version: remove unused InvalidInputError class

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -109,13 +109,6 @@ requirements:
 '''
 
 
-class InvalidInputError(Exception):
-    """ Invalid user input for a parameter """
-    def __init__(self, param, value):
-        self.param = param
-        self.value = value
-
-
 def get_product_version(client, product, name):
     # We cannot query directly by name yet if the name has a "." character.
     # See CLOUDWF-3.


### PR DESCRIPTION
Nothing in the `errata_tool_product_version` module uses this class. It was a bad copy-and-paste from other modules. We can simply remove it.