### PR TITLE
mergify: require integration tests to pass

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,7 @@ pull_request_rules:
       - author=ktdreyer
       - status-success=Travis CI - Pull Request
       - status-success=Travis CI - Branch
+      - status-success=integration
       - base=master
     actions:
       merge:


### PR DESCRIPTION
The new GitHub Action integration tests have been working for a while.  Gate Mergify's activity on the integration tests. With this change, Mergify will only auto-merge PRs if the integration tests pass.