### PR TITLE
fix yamllint errors in .travis.yml and .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,4 +16,3 @@ pull_request_rules:
       - merged
     actions:
       delete_head_branch: {}
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: python
 python:
-- 2.7
-- 3.6
-- 3.7
+  - 2.7
+  - 3.6
+  - 3.7
 install: pip install tox-travis
 script: tox
 
 jobs:
   include:
-  - python: 3.8
-    after_success:
-    - pip install coveralls
-    - coveralls
+    - python: 3.8
+      after_success:
+        - pip install coveralls
+        - coveralls
 
-  - name: test collection build
-    install: pip install ansible
-    script: tests/integration/collection.sh
-    addons:
-     apt:
-       packages:
-       - pandoc
+    - name: test collection build
+      install: pip install ansible
+      script: tests/integration/collection.sh
+      addons:
+        apt:
+          packages:
+            - pandoc
 
 cache:
   directories:
-  - $HOME/.cache/pip
+    - $HOME/.cache/pip


### PR DESCRIPTION
Fix the errors that yamllint finds in `.travis.yml` and `.mergify.yml`.