### PR TITLE
tests: remove py37 from tox and travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 2.7
   - 3.6
-  - 3.7
 install: pip install tox-travis
 script: tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, flake8
+envlist = py27, py36, py38, flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
RHEL 7 has py36

RHEL 8 has py36 and py38

Fedora 32 has py38

Fedora 33 will have py39

I don't care about py37 at this point. Drop it from our Tox and Travis CI configuration to save time and energy.