### PR TITLE
release: improve history checking in test_create_release()

### DIFF
--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -130,7 +130,6 @@ class TestCreateRelease(object):
             status_code=201)
         create_release(client, params)
         history = client.adapter.request_history
-        assert len(history) == 5
         expected = {
             'release': {
                 'name': 'rhceph-4.0',
@@ -158,9 +157,9 @@ class TestCreateRelease(object):
             },
             'type': 'QuarterlyUpdate',
         }
-        assert history[4].url == PROD + '/api/v1/releases'
-        assert history[4].method == 'POST'
-        assert history[4].json() == expected
+        assert history[-1].url == PROD + '/api/v1/releases'
+        assert history[-1].method == 'POST'
+        assert history[-1].json() == expected
 
     def test_error(self, client, params):
         """ Ensure that we raise any server message to the user. """


### PR DESCRIPTION
Check for the final HTTP request in the history, rather than counting the requests and hard-coding the length.

This makes this test more resiliant against future design changes. For example, CLOUDWF-298 is an RFE to allow setting parameters by name instead of ID number, which would reduce the number of HTTP GET calls we make to look up ID numbers, breaking the hard-coded history index numbers.

This change also makes it easier to understand the intention of the unit test: we only care about "the final" HTTP request, rather than "the fifth" request.