### PR TITLE
release: clean up unit test fixtures

### DIFF
--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -174,7 +174,7 @@ class TestCreateRelease(object):
 
 class TestEditRelease(object):
 
-    def test_edit_release(self, client, params):
+    def test_edit_release(self, client):
         client.adapter.register_uri(
             'PUT',
             PROD + '/api/v1/releases/1017')
@@ -192,7 +192,7 @@ class TestEditRelease(object):
         }
         assert history[0].json() == expected
 
-    def test_error(self, client, params):
+    def test_error(self, client):
         """ Ensure that we raise any server message to the user. """
         client.adapter.register_uri(
             'PUT',

--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -22,7 +22,6 @@ def params():
         'active': True,
         'enable_batching': False,
         'program_manager': 'coolmanager@redhat.com',
-        'state_machine_rule_set': None,
         'blocker_flags': ['ceph-4'],
         'internal_target_release': "",
         'zstream_target_release': None,


### PR DESCRIPTION
Clean up the `errata_tool_release` module unit tests in two ways:

1. Remove a duplicate key in the `params()` test fixture.
2. Remove unused `params` fixtures from `TestEditRelease`.