### PR TITLE
variant: assert null cpe in layered product integration test

### DIFF
--- a/tests/integration/errata_tool_variant/create-2.yml
+++ b/tests/integration/errata_tool_variant/create-2.yml
@@ -59,6 +59,7 @@
     that:
       - attributes.name == '8Base-Test-Create-Variants-2.0-Tools'
       - attributes.description == "Test variant on a layered product 2.0"
+      - attributes.cpe is none
       - attributes.enabled
       - not attributes.buildroot
       - attributes.tps_stream == "RHEL-8-Main-Base"


### PR DESCRIPTION
We don't specify the `cpe` parameter in the `errata_tool_variant` task.  Ensure that the default value is the one we expect.