### PR TITLE
do not send "null" values to ET API

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -505,6 +505,7 @@ def ensure_cdn_repo(client, check_mode, params):
     :param dict params: Parameters from ansible
     """
     result = {'changed': False, 'stdout_lines': []}
+    params = {param: val for param, val in params.items() if val is not None}
     name = params['name']
 
     # Special handling for packages parameter:

--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -238,9 +238,9 @@ def html_form_data(client, params):
     data['product[valid_bug_states][]'] = params['valid_bug_states']
     data['product[isactive]'] = int(params['active'])
     data['product[ftp_path]'] = params['ftp_path']
-    data['product[ftp_subdir]'] = params['ftp_subdir']
+    data['product[ftp_subdir]'] = params.get('ftp_subdir', '')
     data['product[is_internal]'] = int(params['internal'])
-    if params['default_docs_reviewer'] is not None:
+    if params.get('default_docs_reviewer') is not None:
         default_docs_reviewer_id = common_errata_tool.user_id(client, params['default_docs_reviewer'])
         data['product[default_docs_reviewer_id]'] = default_docs_reviewer_id
     # push targets need scraper
@@ -313,6 +313,7 @@ def edit_product(client, product_id, params):
 
 def ensure_product(client, params, check_mode):
     result = {'changed': False, 'stdout_lines': []}
+    params = {param: val for param, val in params.items() if val is not None}
     short_name = params['short_name']
     product = get_product(client, short_name)
     if not product:

--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -236,6 +236,7 @@ def edit_product_version(client, product_version, differences):
 
 def ensure_product_version(client, params, check_mode):
     result = {'changed': False, 'stdout_lines': []}
+    params = {param: val for param, val in params.items() if val is not None}
     product = params['product']
     name = params['name']
     product_version = get_product_version(client, product, name)

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -275,9 +275,7 @@ def api_data(client, params):
     # Update the values for ones that the REST API will accept:
     if 'product' in release:
         product_name = release.pop('product')
-        if product_name is None:
-            release['product_id'] = None
-        else:
+        if product_name is not None:
             release['product_id'] = get_product_id(client, product_name)
     if 'program_manager' in release:
         pm_login_name = release.pop('program_manager')
@@ -340,6 +338,8 @@ def ensure_release(client, params, check_mode):
     # Note: this looks identical to the diff_product() method.
     # Maybe we can generalize this.
     result = {'changed': False, 'stdout_lines': []}
+    params = {param: val for param, val in params.items() if val is not None}
+
     name = params['name']
     release = get_release(client, name)
     if not release:

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -131,11 +131,15 @@ options:
    state_machine_rule_set:
      description:
        - Workflow Rule Set
-       - Set to "null" to simply inherit the main workflow_rule_set
-         configuration from this release's product.
-       - If you omit this parameter, Ansible will default to "null" and re-set
-         the release's workflow ruleset back to null (so, inheriting the
-         product's ruleset).
+       - If you omit this parameter, Ansible will default to "null". For new
+         releases, this means the release will inherit the product's ruleset.
+         For existing releases, Ansible will not edit the server-side value if
+         this is null.
+       - To force Ansible to change an existing release's
+         state_machine_rule_set to "null" on the ET server, set this parameter
+         to an empty string "". For example, if the current rule set was
+         "unrestricted" and you wanted to alter it to "null" (to inherit from
+         the parent product), use an empty string here.
      choices: [Default, Unrestricted, CDN Push Only, Covscan,
                Non-blocking TPS, Optional TPS DistQA, Non-blocking rpmdiff for
                RHEL-8, Ansible, RHEL-8 GA, Non-blocking TPS & Covscan,
@@ -339,6 +343,11 @@ def ensure_release(client, params, check_mode):
     # Maybe we can generalize this.
     result = {'changed': False, 'stdout_lines': []}
     params = {param: val for param, val in params.items() if val is not None}
+
+    # Special-case state_machine_rule_set, because it's an enum, and it's
+    # important to be able to set this back to "null" if desired:
+    if params.get('state_machine_rule_set') == '':
+        params['state_machine_rule_set'] = None
 
     name = params['name']
     release = get_release(client, name)

--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -123,7 +123,7 @@ def create_user(client, params):
 
     # Hack for CLOUDWF-2817 - If the user's receives_mail attribute is true,
     # we must always send the intended email_address as well.
-    if params['receives_mail'] and params['email_address'] is None:
+    if params['receives_mail'] and params.get('email_address') is None:
         # The user wanted the ET to choose a default email address, so we
         # approximate that here:
         account_name, _ = params['login_name'].split('@', 1)
@@ -159,6 +159,7 @@ def edit_user(client, user_id, differences):
 
 def ensure_user(client, params, check_mode):
     result = {'changed': False, 'stdout_lines': []}
+    params = {param: val for param, val in params.items() if val is not None}
     login_name = params['login_name']
     user = get_user(client, login_name)
     if not user:
@@ -168,11 +169,6 @@ def ensure_user(client, params, check_mode):
             create_user(client, params)
         return result
     user_id = user.pop('id')
-
-    # Do not change these settings if the playbook author omits them ("None").
-    for param in ('organization', 'roles', 'email_address'):
-        if params[param] is None:
-            params.pop(param)
 
     differences = common_errata_tool.diff_settings(user, params)
     if differences:

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -154,6 +154,7 @@ def edit_variant(client, variant_id, differences):
 
 def ensure_variant(client, params, check_mode):
     result = {'changed': False, 'stdout_lines': []}
+    params = {param: val for param, val in params.items() if val is not None}
     name = params['name']
     variant = get_variant(client, name)
 
@@ -163,9 +164,6 @@ def ensure_variant(client, params, check_mode):
         if not check_mode:
             create_variant(client, params)
         return result
-    # Don't print a diff for CPE if it was omitted
-    if params['cpe'] is None:
-        params.pop('cpe')
     differences = common_errata_tool.diff_settings(variant, params)
     if differences:
         result['changed'] = True

--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -186,7 +186,6 @@ class TestCreateRelease(object):
                 'name': 'rhceph-4.0',
                 'description': 'Red Hat Ceph Storage 4.0',
                 'brew_tags': [],
-                'product_id': None,
                 'program_manager_id': 123456,
                 'product_version_ids': [929, 1108],
                 'state_machine_rule_set_id': None,


### PR DESCRIPTION
Make `null` mean "the server will choose a value for new resources, or not edit an existing resource's value".

Some modules had a couple `if parameter is None: ...` conditionals to specially handle individual null values. Drop these special cases since we're generalizing this convention across all modules and parameters now.

This is a prerequisite to resolving #129. After we merge this, we need to review each parameter with a "default" value, figure out how we can default it to "None", and then document what the server does when we create a resource without that parameter.