### PR TITLE
release: improve blocker_flags default behavior

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -65,9 +65,11 @@ options:
      description:
        - Bugzilla blocker flags (specify a list).
        - "Example: [ceph-3.0, devel_ack, qa_ack, pm_ack]"
-       - Optional for Async errata (or all advisories at this point?)
+       - If the release is a Zstream (or QuarterlyUpdate with
+         supports_component_acl), you must specify at least one flag here. If
+         the release is an Async, blocker_flags is not required.
      required: false
-     default: []
+     default: null
    internal_target_release:
      description:
        - Internal release target Bugzilla field
@@ -390,7 +392,7 @@ def run_module():
         active=dict(type='bool', default=True),
         enable_batching=dict(type='bool', default=True),
         program_manager=dict(required=True),
-        blocker_flags=dict(type='list', default=[]),
+        blocker_flags=dict(type='list'),
         internal_target_release=dict(),
         zstream_target_release=dict(),
         ship_date=dict(),


### PR DESCRIPTION
Prior to this change, if a user specified no `blocker_flags` parameter, we passed an empty list to the ET when creating or editing a variant.

A default empty list is not good for two reasons:

1) If a playbook author omits this setting, Ansible will surprisingly reset the values on the server.

2) It's not possible to set an empty list for `Zstream` releases (or `QuarterlyUpdate` releases with `supports_component_acl`: `true`). The server error is: `{"blocker_flags": ["Need a release version flag"]}`

Default `blocker_flags` to `null` (and we do not send the `blocker_flags` value to the API at all if it is `null`).

Related: #129