### PR TITLE
common: add unit tests for PushTargetScraper

### DIFF
--- a/tests/fixtures/products_new.html
+++ b/tests/fixtures/products_new.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+
+<!-- hand-crafted HTML fixture for testing scraping push target IDs -->
+
+<html>
+
+<body>
+
+<h1>New Product</h1>
+
+<table>
+
+<tr><td>Allowed Push Targets</td>
+<td>  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="2" class="external_true" />&nbsp;
+      Push to RHN Stage <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="1" class="external_true" />&nbsp;
+      Push to RHN Live <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="3" class="external_true" />&nbsp;
+      Push to public FTP server <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="5" class="external_true" />&nbsp;
+      Push to CDN Stage <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="9" class="external_true" />&nbsp;
+      Push docker images to CDN docker stage <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="8" class="external_true" />&nbsp;
+      Push docker images to CDN <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="4" class="external_true" />&nbsp;
+      Push to CDN Live <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="product[push_targets][]" id="product_push_targets_" value="6" class="external_true" />&nbsp;
+      Push sources to CentOS git <span>(Pub Target: foobar)</span>
+    </label>
+  </div>
+
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
Add unit test coverage for the `PushTargetScraper` class.

The `products_new.html` fixture file is a manually-sanitized version of the ET HTML page, just enough so that we can pass it through the scraper.