### PR TITLE
common: fix comment about need for PushTargetScraper

### DIFF
--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -33,7 +33,7 @@ class PushTargetScraper(object):
     years.
 
     Once we have the ability to edit all Push Target settings by name instead
-    of ID, we can delete this method.
+    of ID, we can delete this class.
     """
     # Map PushTarget descriptions to names. This map comes from
     # /developer-guide/push-push-targets-options-and-tasks.html


### PR DESCRIPTION
`PushTargetScraper` is a full class now, not just a simple method. Update the docstring comment to reflect the fact that we will delete the entire class once we can edit Push Targets by name. This change makes it easier to understand this sentence.