### PR TITLE
product_version: wrap rhel_release_name assignment at 80 characters

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -135,7 +135,8 @@ def get_product_version(client, product, name):
     data = product_versions[0]
     product_version = data['attributes']
     product_version['brew_tags'] = data['brew_tags']
-    product_version['rhel_release_name'] = data['relationships']['rhel_release']['name']
+    rhel_release = data['relationships']['rhel_release']['name']
+    product_version['rhel_release_name'] = rhel_release
     product_version['sig_key_name'] = data['relationships']['sig_key']['name']
     # push_targets
     push_targets = [t['name'] for t in data['relationships']['push_targets']]


### PR DESCRIPTION
Shorten and break up the code so that the lines wrap at 80 characters to satisfy linters.