### PR TITLE
tox: report all flake8 warnings and errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]
 deps=flake8
-commands=flake8 --select=F,E9 {posargs:library}
+commands=flake8 {posargs:library}


### PR DESCRIPTION
Update the tox configuration for the "flake8" environment so that we do not hide any warnings or errors.

This will cause `tox -e flake8` to fail on line length problems and anything else.