### PR TITLE
tox: run flake8 against module_utils

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]
 deps=flake8
-commands=flake8 {posargs:library}
+commands=flake8 {posargs:library module_utils}


### PR DESCRIPTION
Prior to this change, `tox -e flake8` would skip checking the `module_utils` directory. This meant that we did not report flake8 issues in `common_errata_tool.py`.

Update the `flake8` command to run against both the `library` and `module_utils` directories. With this change, we will lint the full Ansible module codebase (ignoring tests).