### PR TITLE
release: add integration tests

### DIFF
--- a/tests/integration/errata_tool_release/blocker-flags-1.yml
+++ b/tests/integration/errata_tool_release/blocker-flags-1.yml
@@ -1,0 +1,202 @@
+# Test blocker_bug settings when creating releases.
+#
+# This test case exercises the ability to set (or not set) the blocker_bug
+# parameter when creating different releases.
+
+# This assumes the "RHEL" product is pre-configured.
+# The errata-rails.git test/fixtures/errata_products.yml file does this.
+---
+
+- name: Add prerequisite program manager Errata Tool account
+  errata_tool_user:
+    login_name: rhelpm@redhat.com
+    realname: Cool RHEL ProgramManager
+    organization: Program Management
+    receives_mail: false
+    roles:
+      - pm
+
+###########
+
+- name: QuarterlyUpdate with supports_component_acl and no blocker flags
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-quarterly-acl-no-blocker
+    type: QuarterlyUpdate
+    description: should fail because ACLs require blocker flags
+    ship_date: '2019-05-07'
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    supports_component_acl: true
+  register: result
+  ignore_errors: yes
+
+- name: assert ET server-side failure for QU with ACL and no blocker flags
+  assert:
+    that:
+      - result.failed
+      # TODO: assert failure message here, once we have a friendly error
+      # message (instead of a stack trace).
+
+###########
+
+- name: QuarterlyUpdate with supports_component_acl and a blocker flag
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-quarterly-acl-with-blocker
+    type: QuarterlyUpdate
+    description: QuarterlyUpdate with ACL and a blocker flag
+    ship_date: '2019-05-07'
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    supports_component_acl: true
+    blocker_flags: [rhel-8.0.0]
+  register: result
+
+- name: query API for blocker-bug-1-quarterly-acl-with-blocker release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=blocker-bug-1-quarterly-acl-with-blocker
+  register: result
+
+- name: assert blocker-bug-1-quarterly-acl-with-blocker looks correct in ET
+  assert:
+    that:
+      - result.json.data.0.attributes.supports_component_acl
+      - result.json.data.0.attributes.blocker_flags == ["rhel-8.0.0"]
+
+###########
+
+- name: QuarterlyUpdate without supports_component_acl and no blocker flags
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-quarterly-no-acl-no-blocker
+    type: QuarterlyUpdate
+    description: QuarterlyUpdate with no ACL and no blocker flags
+    ship_date: '2019-05-07'
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: query API for blocker-bug-1-quarterly-no-acl-no-blocker release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=blocker-bug-1-quarterly-no-acl-no-blocker
+  register: result
+
+- name: assert blocker-bug-1-quarterly-no-acl-no-blocker looks correct in ET
+  assert:
+    that:
+      - not result.json.data.0.attributes.supports_component_acl
+      - result.json.data.0.attributes.blocker_flags == []
+
+###########
+
+- name: QuarterlyUpdate without supports_component_acl and with a blocker flag
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-quarterly-no-acl-with-blocker
+    type: QuarterlyUpdate
+    description: QuarterlyUpdate with no ACL and with a blocker flag
+    ship_date: '2019-05-07'
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    blocker_flags: [rhel-8.0.0]
+  register: result
+
+- name: query API for blocker-bug-1-quarterly-no-acl-with-blocker release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=blocker-bug-1-quarterly-no-acl-with-blocker
+  register: result
+
+- name: assert blocker-bug-1-quarterly-no-acl-with-blocker looks correct in ET
+  assert:
+    that:
+      - not result.json.data.0.attributes.supports_component_acl
+      - result.json.data.0.attributes.blocker_flags == ["rhel-8.0.0"]
+
+###########
+
+- name: Zstream with no blocker flags
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-zstream-no-blocker
+    type: Zstream
+    description: should fail because Zstreams always require blocker flags.
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+  ignore_errors: yes
+
+- name: assert ET server-side failure for Zstream with no blocker flags
+  assert:
+    that:
+      - result.failed
+      # TODO: assert failure message here, once we have a friendly error
+      # message (instead of a stack trace).
+
+###########
+
+- name: Zstream with a blocker flag
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-zstream-with-blocker
+    type: Zstream
+    description: Zstream with a blocker flag
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    blocker_flags: [rhel-8.0.0]
+  register: result
+
+- name: query API for blocker-bug-1-zstream-with-blocker release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=blocker-bug-1-zstream-with-blocker
+  register: result
+
+- name: assert blocker-bug-1-zstream-with-blocker looks correct in ET
+  assert:
+    that:
+      - result.json.data.0.attributes.blocker_flags == ["rhel-8.0.0"]
+
+###########
+
+- name: Async with no blocker flags
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-async-no-blocker
+    type: Async
+    description: Async with no blocker flags
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: query API for blocker-bug-1-async-no-blocker release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=blocker-bug-1-async-no-blocker
+  register: result
+
+- name: assert blocker-bug-1-async-no-blocker looks correct in ET
+  assert:
+    that:
+      - result.json.data.0.attributes.blocker_flags == []
+
+###########
+
+- name: Async with a blocker flag
+  errata_tool_release:
+    product: RHEL
+    name: blocker-bug-1-async-with-blocker
+    type: Async
+    description: Async with a blocker flag
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    blocker_flags: [rhel-8.0.0]
+  register: result
+
+- name: query API for blocker-bug-1-async-with-blocker release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=blocker-bug-1-async-with-blocker
+  register: result
+
+- name: assert blocker-bug-1-async-with-blocker looks correct in ET
+  assert:
+    that:
+      - result.json.data.0.attributes.blocker_flags == ["rhel-8.0.0"]

--- a/tests/integration/errata_tool_release/create-1.yml
+++ b/tests/integration/errata_tool_release/create-1.yml
@@ -1,0 +1,106 @@
+# Configure three new minimal RHEL 8 releases.
+#
+# This test case exercises the ability to create QuarterlyUpdate, Zstream, and
+# Async releases.
+
+# This assumes the "RHEL" product is pre-configured.
+# The errata-rails.git test/fixtures/errata_products.yml file does this.
+---
+
+- name: Add program manager Errata Tool account
+  errata_tool_user:
+    login_name: rhelpm@redhat.com
+    realname: Cool RHEL ProgramManager
+    organization: Program Management
+    receives_mail: false
+    roles:
+      - pm
+
+- name: Add new RHEL 8.0.0 QuarterlyUpdate
+  errata_tool_release:
+    product: RHEL
+    name: RHEL-8.0.0.GA
+    type: QuarterlyUpdate
+    description: RHEL-8.0.0 GA
+    ship_date: '2019-05-07'
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    blocker_flags: [rhel-8.0.0]
+  register: quarterlyupdate
+
+- name: Add new RHEL 8.0.0 Zstream
+  errata_tool_release:
+    name: RHEL-8.0.0.Z
+    type: Zstream
+    description: RHEL-8.0.0 Zstream
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    blocker_flags: [rhel-8.0.0]
+  register: zstream
+
+- name: Add new RHEL 8.0.0 Async
+  errata_tool_release:
+    name: RHEL-8.0.0.Async
+    type: Async
+    description: RHEL-8.0.0 Async
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: async
+
+- name: Assert that the module responses are correct
+  assert:
+    that:
+      - quarterlyupdate.changed
+      - quarterlyupdate.stdout_lines == ['created RHEL-8.0.0.GA']
+      - zstream.changed
+      - zstream.stdout_lines == ['created RHEL-8.0.0.Z']
+      - async.changed
+      - async.stdout_lines == ['created RHEL-8.0.0.Async']
+
+# Assert that these releases look correct.
+
+# We cannot get the names directly yet, CLOUDWF-1
+- name: query API for QuarterlyUpdate release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=RHEL-8.0.0.GA
+  register: quarterlyupdate
+
+- name: query API for Zstream release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=RHEL-8.0.0.Z
+  register: zstream
+
+- name: query API for Async release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=RHEL-8.0.0.Async
+  register: async
+
+- name: parse releases JSON
+  set_fact:
+    quarterlyupdate_attributes: "{{ quarterlyupdate.json.data.0.attributes }}"
+    quarterlyupdate_relationships: "{{ quarterlyupdate.json.data.0.relationships }}"
+    zstream_attributes: "{{ zstream.json.data.0.attributes }}"
+    zstream_relationships: "{{ zstream.json.data.0.relationships }}"
+    async_attributes: "{{ async.json.data.0.attributes }}"
+    async_relationships: "{{ async.json.data.0.relationships }}"
+
+- assert:
+    that:
+      - quarterlyupdate_attributes.name == 'RHEL-8.0.0.GA'
+      - quarterlyupdate_attributes.type == 'QuarterlyUpdate'
+      - quarterlyupdate_attributes.description == 'RHEL-8.0.0 GA'
+      - quarterlyupdate_attributes.ship_date == '2019-05-07T00:00:00Z'
+      - quarterlyupdate_relationships.product.short_name == 'RHEL'
+      - quarterlyupdate_relationships.program_manager.login_name == 'rhelpm@redhat.com'
+
+      - zstream_attributes.name == 'RHEL-8.0.0.Z'
+      - zstream_attributes.type == 'Zstream'
+      - zstream_attributes.description == 'RHEL-8.0.0 Zstream'
+      - zstream_attributes.ship_date is none
+      - zstream_relationships.program_manager.login_name == 'rhelpm@redhat.com'
+
+      - async_attributes.name == 'RHEL-8.0.0.Async'
+      - async_attributes.type == 'Async'
+      - async_attributes.description == 'RHEL-8.0.0 Async'
+      - async_attributes.ship_date is none
+      - async_relationships.program_manager.login_name == 'rhelpm@redhat.com'

--- a/tests/integration/errata_tool_release/create-2.yml
+++ b/tests/integration/errata_tool_release/create-2.yml
@@ -1,0 +1,42 @@
+# Configure an async release with no product.
+#
+---
+
+- name: Add program manager Errata Tool account
+  errata_tool_user:
+    login_name: rhelpm@redhat.com
+    realname: Cool RHEL ProgramManager
+    organization: Program Management
+    receives_mail: false
+    roles:
+      - pm
+
+- name: Add new create-2 Async
+  errata_tool_release:
+    name: create-2
+    type: Async
+    description: create-2 async test
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+
+# Assert that this release looks correct.
+
+# We cannot get the names directly yet, CLOUDWF-1
+- name: query API for Async release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=create-2
+  register: async
+
+- name: parse release JSON
+  set_fact:
+    attributes: "{{ async.json.data.0.attributes }}"
+    relationships: "{{ async.json.data.0.relationships }}"
+
+- assert:
+    that:
+      - attributes.name == 'create-2'
+      - attributes.type == 'Async'
+      - attributes.description == 'create-2 async test'
+      - attributes.ship_date is none
+      - relationships.program_manager.login_name == 'rhelpm@redhat.com'
+      - relationships.product is none

--- a/tests/integration/errata_tool_release/main.yml
+++ b/tests/integration/errata_tool_release/main.yml
@@ -1,0 +1,1 @@
+../main.yml.in

--- a/tests/integration/errata_tool_release/pelc-product-version-name-1.yml
+++ b/tests/integration/errata_tool_release/pelc-product-version-name-1.yml
@@ -1,0 +1,158 @@
+# Test editing pelc_product_version_name settings.
+#
+# This test case exercises the ability to set (or not set) the
+# pelc_product_version_name parameter.
+
+# This assumes the "RHEL" product is pre-configured.
+# The errata-rails.git test/fixtures/errata_products.yml file does this.
+---
+
+- name: Add prerequisite program manager Errata Tool account
+  errata_tool_user:
+    login_name: rhelpm@redhat.com
+    realname: Cool RHEL ProgramManager
+    organization: Program Management
+    receives_mail: false
+    roles:
+      - pm
+
+###########
+
+- name: Create a release with no pelc_product_version_name
+  errata_tool_release:
+    product: RHEL
+    name: pelc-product-version-name-1
+    type: Async
+    description: Testing PELC Product Version Name
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert pelc-product-version-name-1 is a new release
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["created pelc-product-version-name-1"]
+
+- name: query API for pelc-product-version-name-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=pelc-product-version-name-1
+  register: result
+
+- name: assert new release has no pelc_product_version_name
+  assert:
+    that:
+      - result.json.data.0.attributes.pelc_product_version_name is none
+
+###########
+
+- name: Edit a release when existing pelc_pv_name is null and we do not specify pelc_product_version_name
+  # same parameters as above, to test "no changes":
+  errata_tool_release:
+    product: RHEL
+    name: pelc-product-version-name-1
+    type: Async
+    description: Testing PELC Product Version Name
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert errata_tool_release reports no changes
+  assert:
+    that:
+      - not result.changed
+
+- name: query API for pelc-product-version-name-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=pelc-product-version-name-1
+  register: result
+
+- name: assert release still has no pelc_product_version_name
+  assert:
+    that:
+      - result.json.data.0.attributes.pelc_product_version_name is none
+
+###########
+
+- name: Edit a release when existing pelc_pv_name is null and we set pelc_product_version_name to rhel-8
+  errata_tool_release:
+    product: RHEL
+    name: pelc-product-version-name-1
+    type: Async
+    description: Testing PELC Product Version Name
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    pelc_product_version_name: rhel-8
+  register: result
+
+- name: assert module reports pelc_product_version_name changing
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["changing pelc_product_version_name from None to rhel-8"]
+
+- name: query API for pelc-product-version-name-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=pelc-product-version-name-1
+  register: result
+
+- name: assert release has a new pelc_product_version_name "rhel-8" value
+  assert:
+    that:
+      - result.json.data.0.attributes.pelc_product_version_name == "rhel-8"
+
+###########
+
+- name: Edit a release when existing pelc_pv_name is "rhel-8" and we do not specify pelc_product_version_name
+  errata_tool_release:
+    product: RHEL
+    name: pelc-product-version-name-1
+    type: Async
+    description: Testing PELC Product Version Name
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert errata_tool_release reports no changes
+  assert:
+    that:
+      - not result.changed
+
+- name: query API for pelc-product-version-name-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=pelc-product-version-name-1
+  register: result
+
+- name: assert release's pelc_product_version_name value is still "rhel-8"
+  assert:
+    that:
+      - result.json.data.0.attributes.pelc_product_version_name == "rhel-8"
+
+###########
+
+- name: Edit a release when existing pelc_pv_name is rhel-8 and we specify pelc_product_version_name=""
+  errata_tool_release:
+    product: RHEL
+    name: pelc-product-version-name-1
+    type: Async
+    description: Testing PELC Product Version Name
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    pelc_product_version_name: ""
+  register: result
+
+- name: assert module reports pelc_product_version_name changing
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["changing pelc_product_version_name from rhel-8 to "]
+
+- name: query API for pelc-product-version-name-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=pelc-product-version-name-1
+  register: result
+
+- name: assert release has a new pelc_product_version_name empty string value
+  assert:
+    that:
+      - result.json.data.0.attributes.pelc_product_version_name == ""

--- a/tests/integration/errata_tool_release/product-versions-1.yml
+++ b/tests/integration/errata_tool_release/product-versions-1.yml
@@ -1,0 +1,104 @@
+# Test editing product_versions settings.
+#
+# This test case exercises the ability to set and unset the product_versions
+# values.
+
+# This assumes the "RHEL" product and "RHEL-8.0.0" product version is
+# pre-configured. The errata-rails.git test/fixtures/errata_products.yml and
+# test/fixtures/product_versions.yml files do this.
+---
+
+- name: Add prerequisite program manager Errata Tool account
+  errata_tool_user:
+    login_name: rhelpm@redhat.com
+    realname: Cool RHEL ProgramManager
+    organization: Program Management
+    receives_mail: false
+    roles:
+      - pm
+
+###########
+
+- name: Create a release with no product_versions
+  errata_tool_release:
+    product: RHEL
+    name: product-versions-1
+    type: Async
+    description: Testing Product Versions
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert product-versions-1 is a new release
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["created product-versions-1"]
+
+- name: query API for product-versions-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=product-versions-1
+  register: result
+
+- name: assert new release has no product_versions
+  assert:
+    that:
+      - result.json.data.0.relationships.product_versions == []
+
+###########
+
+- name: Add a PV to an existing release with no PVs
+  errata_tool_release:
+    product: RHEL
+    name: product-versions-1
+    type: Async
+    description: Testing Product Versions
+    program_manager: rhelpm@redhat.com
+    product_versions: [RHEL-8.0.0]
+  register: result
+
+- name: assert module reports product_versions changing
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["changing product_versions from [] to ['RHEL-8.0.0']"]
+
+- name: query API for product-versions-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=product-versions-1
+  register: result
+
+- name: assert release has a new RHEL-8.0.0 Product Version
+  assert:
+    that:
+      - result.json.data.0.relationships.product_versions.0.name == "RHEL-8.0.0"
+
+###########
+
+- name: Remove all PVs from a release
+  errata_tool_release:
+    product: RHEL
+    name: product-versions-1
+    type: Async
+    description: Testing Product Versions
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert module reports product_versions changing
+  assert:
+    that:
+      - result.changed
+      # TODO: remove "u" when running on py3
+      # (or fix product_versions assignment to always use encoded str on py2):
+      - result.stdout_lines == ["changing product_versions from [u'RHEL-8.0.0'] to []"]
+
+- name: query API for product-versions-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=product-versions-1
+  register: result
+
+- name: assert release has no product_versions
+  assert:
+    that:
+      - result.json.data.0.relationships.product_versions == []

--- a/tests/integration/errata_tool_release/state-machine-rule-set-1.yml
+++ b/tests/integration/errata_tool_release/state-machine-rule-set-1.yml
@@ -1,0 +1,158 @@
+# Test editing state_machine_rule_set settings.
+#
+# This test case exercises the ability to set (or not set) the
+# state_machine_rule_set parameter.
+
+# This assumes the "RHEL" product is pre-configured.
+# The errata-rails.git test/fixtures/errata_products.yml file does this.
+---
+
+- name: Add prerequisite program manager Errata Tool account
+  errata_tool_user:
+    login_name: rhelpm@redhat.com
+    realname: Cool RHEL ProgramManager
+    organization: Program Management
+    receives_mail: false
+    roles:
+      - pm
+
+###########
+
+- name: Create a release with no state_machine_rule_set
+  errata_tool_release:
+    product: RHEL
+    name: state-machine-rule-set-1
+    type: Async
+    description: Testing Workflow Rule Set
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert state-machine-rule-set-1 is a new release
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["created state-machine-rule-set-1"]
+
+- name: query API for state-machine-rule-set-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=state-machine-rule-set-1
+  register: result
+
+- name: assert new release has no state_machine_rule_set
+  assert:
+    that:
+      - result.json.data.0.relationships.state_machine_rule_set is none
+
+###########
+
+- name: Edit a release when existing rule_set is null and we do not specify state_machine_rule_set
+  # same parameters as above, to test "no changes":
+  errata_tool_release:
+    product: RHEL
+    name: state-machine-rule-set-1
+    type: Async
+    description: Testing Workflow Rule Set
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert errata_tool_release reports no changes
+  assert:
+    that:
+      - not result.changed
+
+- name: query API for state-machine-rule-set-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=state-machine-rule-set-1
+  register: result
+
+- name: assert release still has no state_machine_rule_set
+  assert:
+    that:
+      - result.json.data.0.relationships.state_machine_rule_set is none
+
+###########
+
+- name: Edit a release when existing rule_set is null and we set state_machine_rule_set to Unrestricted
+  errata_tool_release:
+    product: RHEL
+    name: state-machine-rule-set-1
+    type: Async
+    description: Testing Workflow Rule Set
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    state_machine_rule_set: Unrestricted
+  register: result
+
+- name: assert module reports state_machine_rule_set changing
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["changing state_machine_rule_set from None to Unrestricted"]
+
+- name: query API for state-machine-rule-set-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=state-machine-rule-set-1
+  register: result
+
+- name: assert release has a new state_machine_rule_set "Unrestricted" value
+  assert:
+    that:
+      - result.json.data.0.relationships.state_machine_rule_set.name == "Unrestricted"
+
+###########
+
+- name: Edit a release when existing rule_set is "Unrestricted" and we do not specify state_machine_rule_set
+  errata_tool_release:
+    product: RHEL
+    name: state-machine-rule-set-1
+    type: Async
+    description: Testing Workflow Rule Set
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+  register: result
+
+- name: assert errata_tool_release reports no changes
+  assert:
+    that:
+      - not result.changed
+
+- name: query API for state-machine-rule-set-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=state-machine-rule-set-1
+  register: result
+
+- name: assert release's state_machine_rule_set value is still "Unrestricted"
+  assert:
+    that:
+      - result.json.data.0.relationships.state_machine_rule_set.name == "Unrestricted"
+
+###########
+
+- name: Edit a release when existing rule_set is Unrestricted and we specify state_machine_rule_set=""
+  errata_tool_release:
+    product: RHEL
+    name: state-machine-rule-set-1
+    type: Async
+    description: Testing Workflow Rule Set
+    program_manager: rhelpm@redhat.com
+    product_versions: []
+    state_machine_rule_set: ""
+  register: result
+
+- name: assert module reports state_machine_rule_set changing
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["changing state_machine_rule_set from Unrestricted to None"]
+
+- name: query API for state-machine-rule-set-1 release
+  errata_tool_request:
+    path: api/v1/releases?filter[name]=state-machine-rule-set-1
+  register: result
+
+- name: assert release has a new state_machine_rule_set empty string value
+  assert:
+    that:
+      - result.json.data.0.relationships.state_machine_rule_set is none


### PR DESCRIPTION
Add a series of integration tests for `errata_tool_release`.

There are two general "create" tests, and some tests that exercise setting + updating + un-setting some attributes (`blocker_flags`, `pelc_product_version_name`, `state_machine_rule_set`, `product_versions`)