### PR TITLE
release: simplify product_versions key search

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -350,13 +350,8 @@ def ensure_release(client, params, check_mode):
         if not check_mode:
             # CLOUDWF-6: we must send product_version_ids in every request,
             # or the server will reset the product versions to an empty list.
-            changing_product_versions = False
-            for difference in differences:
-                key, _, _ = difference
-                if key == 'product_versions':
-                    changing_product_versions = True
-                    break
-            if not changing_product_versions:
+            keys = [difference[0] for difference in differences]
+            if 'product_versions' not in keys:
                 differences.append(('product_versions',
                                     params['product_versions'],
                                     params['product_versions']))


### PR DESCRIPTION
The code for `changing_product_versions` was overly complex. Simplify it by using a list comprehension to determine all the keys we're changing, and then search that list.