### PR TITLE
common: remove unused "Docker stage" push target

### DIFF
--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -44,8 +44,6 @@ class PushTargetScraper(object):
         'Push to CDN Stage': 'cdn_stage',
         'Push docker images to CDN': 'cdn_docker',
         'Push docker images to CDN docker stage': 'cdn_docker_stage',
-        # "docker stage" vs "Docker stage". Remove this after Gerrit 193086:
-        'Push docker images to CDN Docker stage': 'cdn_docker_stage',
         'Push to public FTP server': 'ftp',
         'Push sources to CentOS git': 'altsrc',
         # These two HSS entries are old and deprecated. We include them here


### PR DESCRIPTION
Gerrit 193086 is resolved. The dev ET instances' push target names align with the names in staging and production. We can drop this old code now.

Fixes: #142