### PR TITLE
cdn_repo: fix set_fact name in integration tests

### DIFF
--- a/tests/integration/errata_tool_cdn_repo/create-1.yml
+++ b/tests/integration/errata_tool_cdn_repo/create-1.yml
@@ -21,7 +21,7 @@
     path: api/v1/cdn_repos/redhat-create-1-x86_64-rpms
   register: response
 
-- name: parse variant JSON
+- name: parse cdn repo JSON
   set_fact:
     attributes: "{{ response.json.data.attributes }}"
     relationships: "{{ response.json.data.relationships }}"

--- a/tests/integration/errata_tool_cdn_repo/create-2.yml
+++ b/tests/integration/errata_tool_cdn_repo/create-2.yml
@@ -24,7 +24,7 @@
     path: api/v1/cdn_repos/redhat-container-create-2
   register: response
 
-- name: parse variant JSON
+- name: parse cdn repo JSON
   set_fact:
     attributes: "{{ response.json.data.attributes }}"
     relationships: "{{ response.json.data.relationships }}"


### PR DESCRIPTION
This was a bad copy-and-paste from another test.