### PR TITLE
cdn_repo: report entire JSON response on edit errors

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -302,8 +302,8 @@ def edit_cdn_repo(client, cdn_repo_id, differences):
     data = cdn_repo_api_data(params)
     response = client.put('api/v1/cdn_repos/%d' % cdn_repo_id, json=data)
     if response.status_code != 200:
-        data = response.json()
-        raise ValueError(data['error'])
+        errors = response.json()
+        raise ValueError(errors)
 
 
 def add_package_tag(client, repo_name, package_name, tag_template, variant):

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -233,7 +233,7 @@ class TestCreateCdnRepo(object):
         )
         with pytest.raises(ValueError) as err:
             create_cdn_repo(client, {})
-        assert str(err.value) == 'Bad Request'
+        assert 'Bad Request' in str(err.value)
 
 
 class TestEditCdnRepo(object):
@@ -269,7 +269,24 @@ class TestEditCdnRepo(object):
         differences = [('my-bogus-setting', 'foo', 'bar')]
         with pytest.raises(ValueError) as err:
             edit_cdn_repo(client, 11010, differences)
-        assert str(err.value) == 'Bad Request'
+        assert 'Bad Request' in str(err.value)
+
+    def test_errors(self, client):
+        json = {'errors': {
+            'CDN repository': [
+                'has already been attached to this product version.'
+            ]
+        }}
+        client.adapter.register_uri(
+            'PUT',
+            PROD + '/api/v1/cdn_repos/11010',
+            status_code=422,
+            json=json,
+        )
+        differences = [('variants', ['BaseOS'], ['BaseOS', 'AppStream'])]
+        with pytest.raises(ValueError) as err:
+            edit_cdn_repo(client, 11010, differences)
+        assert 'CDN repository' in str(err.value)
 
 
 class TestGetCdnRepo(object):


### PR DESCRIPTION
Sometimes this API endpoint returns an "errors" key instead of an "error" key. This leads to KeyErrors. (For example, I hit this when I tried to add a second variant to a CDN repo that already had a variant from that same Product Version).

Since we don't have a robust error-handling method, in order to keep this code simple, just raise the entire JSON response, since it's usually pretty small.