### PR TITLE
cdn_repo: prevent use_for_tps with Docker repos

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -579,10 +579,14 @@ def run_module():
         else:
             params['arch'] = 'x86_64'
 
-    # The ET server does not stop users from setting Docker repos to other
-    # arches (CLOUDWF-271). We will guard that here for now.
-    if params['content_type'] == 'Docker' and params['arch'] != 'multi':
-        module.fail_json(msg='arch must be "multi" for Docker repos')
+    # The ET server does not stop users from modifying Docker repos in ways
+    # that are invalid and impossible to fix with the web UI (CLOUDWF-271).
+    # We will guard that here for now.
+    if params['content_type'] == 'Docker':
+        if params['arch'] != 'multi':
+            module.fail_json(msg='arch must be "multi" for Docker repos')
+        if params['use_for_tps']:
+            module.fail_json(msg='do not set "use_for_tps" for Docker repos')
 
     client = common_errata_tool.Client()
 

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -889,3 +889,12 @@ class TestMain(object):
             main()
         result = exit.value.args[0]
         assert result['msg'] == 'arch must be "multi" for Docker repos'
+
+    def test_docker_tps_fail(self, container_module_args):
+        container_module_args['content_type'] = 'Docker'
+        container_module_args['use_for_tps'] = True
+        set_module_args(container_module_args)
+        with pytest.raises(AnsibleFailJson) as exit:
+            main()
+        result = exit.value.args[0]
+        assert result['msg'] == 'do not set "use_for_tps" for Docker repos'


### PR DESCRIPTION
The REST API allows users to set `use_for_tps` on Docker repos, but the HTML UI does not allow it. Until the ET server prevents this misconfiguration, guard against this client-side in the Ansible module.