### PR TITLE
remove tox-gh-actions module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libkrb5-dev
-        pip install tox tox-gh-actions
+        pip install tox
     - name: Test with tox
-      run: tox -- --cov-report=xml tests
+      run: tox -e py -- --cov-report=xml tests
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1
       with:

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,3 @@ commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 [testenv:flake8]
 deps=flake8
 commands=flake8 {posargs:library module_utils}
-
-[gh-actions]
-python =
-    2.7: py27
-    3.6: py36
-    3.8: py38


### PR DESCRIPTION
Tox interprets "-e py" to mean "run tests with the Python version that invoked tox"