### PR TITLE
Expose the response text of a 500 error when configuring a product version

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -152,7 +152,10 @@ def handle_form_errors(response):
     # If there are incorrect or missing fields, we will receive a HTTP 200
     # with a list of the wrong fields, or just an HTTP 500 error.
     if response.status_code == 500:
-        raise RuntimeError(response)
+        raise RuntimeError(
+            'The request to %s had a status code of %d and failed with: %s'
+            % (response.url, response.status_code, response.text)
+        )
     if 'errorExplanation' in response.text:
         raise RuntimeError(response.text)
     response.raise_for_status()

--- a/tests/test_errata_tool_product_version.py
+++ b/tests/test_errata_tool_product_version.py
@@ -1,4 +1,7 @@
-from errata_tool_product_version import get_product_version
+from mock import Mock
+import pytest
+
+from errata_tool_product_version import get_product_version, handle_form_errors
 
 
 PROD = 'https://errata.devel.redhat.com'
@@ -71,3 +74,18 @@ class TestGetProductVersion(object):
             'sig_key_name': 'redhatrelease2'
         }
         assert product_version == expected
+
+
+class TestFormErrors(object):
+
+    def test_handle_form_error_500(self, client):
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.url = PROD
+        mock_response.text = 'Some error'
+        expected = (
+            'The request to https://errata.devel.redhat.com had a status code '
+            'of 500 and failed with: Some error'
+        )
+        with pytest.raises(RuntimeError, match=expected):
+            handle_form_errors(mock_response)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 [testenv]
 deps=
   -r{toxinidir}/requirements.txt
+  mock
   pytest
   pytest-cov
   requests-mock


### PR DESCRIPTION
This will make debugging easier since before this commit, it would just
show an ugly traceback with near the end of it:

RuntimeError: <Response [500]>