### PR TITLE
Show the response text if the cdn_repos failure does not have an error message

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -304,7 +304,7 @@ def create_cdn_repo(client, params):
     response = client.post('api/v1/cdn_repos', json=data)
     data = response.json()
     if response.status_code != 201:
-        raise ValueError(data['error'])
+        raise ValueError(data.get('error') or response.text)
     name = params['name']
     cdn_repo_data = data['data']
     return get_cdn_repo(client, name, cdn_repo_data=cdn_repo_data)

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -235,6 +235,17 @@ class TestCreateCdnRepo(object):
             create_cdn_repo(client, {})
         assert 'Bad Request' in str(err.value)
 
+    def test_failure_error_not_set(self, client):
+        client.adapter.register_uri(
+            'POST',
+            PROD + '/api/v1/cdn_repos',
+            status_code=400,
+            json={'status': 400, 'best_actor': 'Tom Hanks'}
+        )
+        with pytest.raises(ValueError) as err:
+            create_cdn_repo(client, {})
+        assert 'Tom Hanks' in str(err.value)
+
 
 class TestEditCdnRepo(object):
 


### PR DESCRIPTION
If the response from Errata Tool is an error on the api/v1/cdn_repos
API endpoint, show the response text if the JSON does not have the
error key.

This prevents errors such as the following in Ansible:
...
line 307, in create_cdn_repo
KeyError: 'error'
...