### PR TITLE
build-collection: fix VERSION for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch base branches for PR testing
+      run: |
+        git fetch origin master:master
+        [ -z $GITHUB_BASE_REF ] || git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
     - uses: actions/setup-python@v2
     - name: Install pandoc
       run: |

--- a/build-collection
+++ b/build-collection
@@ -38,7 +38,8 @@ fi
 pandoc $TOPDIR/README.rst -f rst -t markdown_strict -o README.md
 
 # Determine our semver-compatible version number from Git.
-BASE_COMMIT=$(git rev-list --max-parents=0 HEAD)
+BASE_REF="${GITHUB_BASE_REF:-HEAD}"
+BASE_COMMIT=$(git rev-list --max-parents=0 $BASE_REF)
 COMMIT_COUNT=$(($(git rev-list --count $BASE_COMMIT..HEAD) - 1))
 
 # Versions will always be 0.0.XXX.


### PR DESCRIPTION
When a GitHub Action runner checks out a pull request for testing, it checks out GitHub's magic "merge" ref. For example:

```
git checkout --progress --force refs/remotes/pull/192/merge
```

This puts the repository into a detached HEAD state. This means that we cannot search `HEAD` for `--max-parents=0`, because Git will simply return the sha we've checked out. This problem means that `COMMIT_COUNT` is always `-1` for pull requests and VERSION is always `0.0.-1`.

GitHub Action runners have a `GITHUB_BASE_REF` environment variable with the name of a pull request base branch. If that is defined, use that to discover the root commit of the base branch. This fixes the `COMMIT_COUNT` calculation for pull requests.

Fixes: #193