### PR TITLE
github: make master fetch non-fatal

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         fetch-depth: 0
     - name: Fetch base branches for PR testing
       run: |
-        git fetch origin master:master
+        git fetch origin master:master || :
         [ -z $GITHUB_BASE_REF ] || git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
     - uses: actions/setup-python@v2
     - name: Install pandoc


### PR DESCRIPTION
When this action runs on a master branch update, the fetch for master will fail here. Treat this as non-fatal.