### PR TITLE
tox: pin to requests-mock 1.8.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
   mock
   pytest
   pytest-cov
-  requests-mock
+  requests-mock==1.8.0
 commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
requests-mock 1.9.0 runs `urlparse.quote()` on paths, and this breaks matching paths like `/api/v1/user/coolmanager@example.com` (the matcher looks for `/api/v1/user/coolmanager%40example.com`).

Pin to the old requests-mock until this is sorted out upstream in https://github.com/jamielennox/requests-mock/issues/158