### PR TITLE
github: fix title of branch fetch steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Fetch base branches for PR testing
+    - name: Fetch base branches for version calculation
       run: |
         git fetch origin master:master || :
         [ -z $GITHUB_BASE_REF ] || git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF


### PR DESCRIPTION
Update the title of this step, so it's clearer why we're fetching these branches.