### PR TITLE
Revert "tox: pin to requests-mock 1.8.0"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
   mock
   pytest
   pytest-cov
-  requests-mock==1.8.0
+  requests-mock
 commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
requests-mock 1.9.2 has fixes quoting on paths, so we can unpin this now.

This reverts commit 58f46416841ade28f4b8266edd85973b0f8945cf.