### PR TITLE
get resources with requests' params

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -258,7 +258,8 @@ def get_cdn_repo(client, name, cdn_repo_data=None):
     """
     if cdn_repo_data is None:
         # CLOUDWF-316 to get cdn_repos directly by name.
-        response = client.get('api/v1/cdn_repos?filter[name]=%s' % name)
+        response = client.get('api/v1/cdn_repos',
+                              params={'filter[name]': name})
         response.raise_for_status()
         json = response.json()
         results = json['data']

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -173,7 +173,7 @@ requirements:
 
 def get_release(client, name):
     # cannot get releases directly by name, CLOUDWF-1
-    r = client.get('api/v1/releases?filter[name]=%s' % name)
+    r = client.get('api/v1/releases', params={'filter[name]': name})
     r.raise_for_status()
     data = r.json()
     results = data['data']

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -91,7 +91,7 @@ def get_variant(client, name):
     """
     # We cannot get the name directly yet, CLOUDWF-4
     # r = client.get('api/v1/variants/%s' % name)
-    r = client.get('api/v1/variants?filter[name]=%s' % name)
+    r = client.get('api/v1/variants', params={'filter[name]': name})
     r.raise_for_status()
     data = r.json()
     results = data['data']

--- a/tests/fixtures/rhel-8.4.0.z+eus.release.json
+++ b/tests/fixtures/rhel-8.4.0.z+eus.release.json
@@ -1,0 +1,55 @@
+{
+  "data": [
+    {
+      "id": 790,
+      "type": "releases",
+      "attributes": {
+        "name": "RHEL-8.4.0.Z.MAIN+EUS",
+        "description": "RHEL-8.4.0.Z.MAIN+EUS",
+        "type": "Zstream",
+        "allow_pkg_dupes": false,
+        "ship_date": "2020-01-01T00:00:00Z",
+        "pelc_product_version_name": null,
+        "is_active": true,
+        "enabled": true,
+        "enable_batching": true,
+        "is_async": true,
+        "is_deferred": false,
+        "allow_shadow": false,
+        "allow_blocker": false,
+        "allow_exception": false,
+        "limit_bugs_by_product": false,
+        "supports_component_acl": false,
+        "blocker_flags": [
+          "release",
+          "zstream"
+        ],
+        "internal_target_release": "",
+        "zstream_target_release": "8.4.0"
+      },
+      "relationships": {
+        "brew_tags": [],
+        "product": {
+          "id": 16,
+          "short_name": "RHEL"
+        },
+        "product_versions": [
+          {
+            "id": 753,
+            "name": "RHEL-8.4.0.Z.MAIN+EUS"
+          }
+        ],
+        "state_machine_rule_set": null,
+        "program_manager": {
+          "id": 123456,
+          "login_name": "coolmanager@redhat.com"
+        }
+      }
+    }
+  ],
+  "page": {
+    "current_page": 1,
+    "total_pages": 1,
+    "result_count": 1
+  }
+}

--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -101,6 +101,16 @@ class TestGetRelease(object):
         result = get_release(client, 'rhceph-4.0')
         assert result[relationship] is None
 
+    def test_plus_character_in_name(self, client):
+        """ Quote "+" characters in release name HTTP request """
+        json = load_json('rhel-8.4.0.z+eus.release.json')
+        client.adapter.register_uri(
+            'GET',
+            PROD + '/api/v1/releases?filter%5Bname%5D=RHEL-8.4.0.Z.MAIN%2BEUS',
+            json=json)
+        result = get_release(client, 'RHEL-8.4.0.Z.MAIN+EUS')
+        assert result['name'] == 'RHEL-8.4.0.Z.MAIN+EUS'
+
 
 class TestCreateRelease(object):
 


### PR DESCRIPTION
Don't manually assemble the GET request filter URL. Use requests' `params` kwarg so that we quote special characters - particularly the `+` character.

This fixes a bug where Ansible would load the wrong URLs for releases, variants, or CDN repos with `+` in names. When Ansible loaded URLs with unquoted `+` characters in the query strings, the ET web server interprets those as spaces, so it would return no results for those named resources. This led Ansible to incorrectly assume the resources did not exist, and Ansible would incorrectly try to create them.

The ET server permits users to create more than one release with the same name (RHELWF-3629), so Ansible could end up creating multiple releases on the server.