### PR TITLE
tests: support Python 3 for integration tests

### DIFF
--- a/tests/integration/errata_tool_cdn_repo/packages-1.yml
+++ b/tests/integration/errata_tool_cdn_repo/packages-1.yml
@@ -171,13 +171,21 @@
     packages: {}
   register: result
 
+- name: set expected changed_message on py2
+  set_fact:
+    changed_message: "changing package_names from [u'test-container'] to []"
+  when: ansible_python_version is version("3", "<")
+
+- name: set expected changed_message on py3
+  set_fact:
+    changed_message: "changing package_names from ['test-container'] to []"
+  when: ansible_python_version is version("3", ">=")
+
 - name: assert module reports CDN repo changing
   assert:
     that:
       - result.changed
-      # TODO: remove "u" when running on py3
-      # (or fix assignment to always use encoded str on py2):
-      - result.stdout_lines == ["changing package_names from [u'test-container'] to []"]
+      - result.stdout_lines == [changed_message]
 
 # Assert that this CDN repo looks correct.
 

--- a/tests/integration/errata_tool_cdn_repo/variants-1.yml
+++ b/tests/integration/errata_tool_cdn_repo/variants-1.yml
@@ -2,9 +2,6 @@
 
 # This assumes the "AppStream-8.0.0" variant is pre-configured. The
 # errata-rails.git test/fixtures/*.yml files do this.
-#
-# This test asserts that module output has a some u'' strings. This is a
-# py2-specific thing. When we run on py3, the module output does not have u''.
 ---
 
 - name: Add prerequisite 8.1.0 Product Version
@@ -72,11 +69,21 @@
       - AppStream-8.1.0
   register: result
 
+- name: set expected changed_message on py2
+  set_fact:
+    changed_message: "changing variants from [u'AppStream-8.0.0'] to ['AppStream-8.0.0', 'AppStream-8.1.0']"
+  when: ansible_python_version is version("3", "<")
+
+- name: set expected changed_message on py3
+  set_fact:
+    changed_message: "changing variants from ['AppStream-8.0.0'] to ['AppStream-8.0.0', 'AppStream-8.1.0']"
+  when: ansible_python_version is version("3", ">=")
+
 - name: assert module reports variants changing
   assert:
     that:
       - result.changed
-      - result.stdout_lines == ["changing variants from [u'AppStream-8.0.0'] to ['AppStream-8.0.0', 'AppStream-8.1.0']"]
+      - result.stdout_lines == [changed_message]
 
 # Assert that this CDN repo looks correct.
 
@@ -107,11 +114,21 @@
       - AppStream-8.0.0
   register: result
 
+- name: set expected changed_message on py2
+  set_fact:
+    changed_message: "changing variants from [u'AppStream-8.0.0', u'AppStream-8.1.0'] to ['AppStream-8.0.0']"
+  when: ansible_python_version is version("3", "<")
+
+- name: set expected changed_message on py3
+  set_fact:
+    changed_message: "changing variants from ['AppStream-8.0.0', 'AppStream-8.1.0'] to ['AppStream-8.0.0']"
+  when: ansible_python_version is version("3", ">=")
+
 - name: assert module reports variants changing
   assert:
     that:
       - result.changed
-      - result.stdout_lines == ["changing variants from [u'AppStream-8.0.0', u'AppStream-8.1.0'] to ['AppStream-8.0.0']"]
+      - result.stdout_lines == [changed_message]
 
 # Assert that this CDN repo looks correct.
 

--- a/tests/integration/errata_tool_release/create-1.yml
+++ b/tests/integration/errata_tool_release/create-1.yml
@@ -46,7 +46,7 @@
     description: RHEL-8.0.0 Async
     program_manager: rhelpm@redhat.com
     product_versions: []
-  register: async
+  register: async_release
 
 - name: Assert that the module responses are correct
   assert:
@@ -55,8 +55,8 @@
       - quarterlyupdate.stdout_lines == ['created RHEL-8.0.0.GA']
       - zstream.changed
       - zstream.stdout_lines == ['created RHEL-8.0.0.Z']
-      - async.changed
-      - async.stdout_lines == ['created RHEL-8.0.0.Async']
+      - async_release.changed
+      - async_release.stdout_lines == ['created RHEL-8.0.0.Async']
 
 # Assert that these releases look correct.
 
@@ -74,7 +74,7 @@
 - name: query API for Async release
   errata_tool_request:
     path: api/v1/releases?filter[name]=RHEL-8.0.0.Async
-  register: async
+  register: async_data
 
 - name: parse releases JSON
   set_fact:
@@ -82,8 +82,8 @@
     quarterlyupdate_relationships: "{{ quarterlyupdate.json.data.0.relationships }}"
     zstream_attributes: "{{ zstream.json.data.0.attributes }}"
     zstream_relationships: "{{ zstream.json.data.0.relationships }}"
-    async_attributes: "{{ async.json.data.0.attributes }}"
-    async_relationships: "{{ async.json.data.0.relationships }}"
+    async_attributes: "{{ async_data.json.data.0.attributes }}"
+    async_relationships: "{{ async_data.json.data.0.relationships }}"
 
 - assert:
     that:

--- a/tests/integration/errata_tool_release/create-2.yml
+++ b/tests/integration/errata_tool_release/create-2.yml
@@ -25,12 +25,12 @@
 - name: query API for Async release
   errata_tool_request:
     path: api/v1/releases?filter[name]=create-2
-  register: async
+  register: async_data
 
 - name: parse release JSON
   set_fact:
-    attributes: "{{ async.json.data.0.attributes }}"
-    relationships: "{{ async.json.data.0.relationships }}"
+    attributes: "{{ async_data.json.data.0.attributes }}"
+    relationships: "{{ async_data.json.data.0.relationships }}"
 
 - assert:
     that:

--- a/tests/integration/errata_tool_release/product-versions-1.yml
+++ b/tests/integration/errata_tool_release/product-versions-1.yml
@@ -85,13 +85,21 @@
     product_versions: []
   register: result
 
+- name: set expected changed_message on py2
+  set_fact:
+    changed_message: "changing product_versions from [u'RHEL-8.0.0'] to []"
+  when: ansible_python_version is version("3", "<")
+
+- name: set expected changed_message on py3
+  set_fact:
+    changed_message: "changing product_versions from ['RHEL-8.0.0'] to []"
+  when: ansible_python_version is version("3", ">=")
+
 - name: assert module reports product_versions changing
   assert:
     that:
       - result.changed
-      # TODO: remove "u" when running on py3
-      # (or fix product_versions assignment to always use encoded str on py2):
-      - result.stdout_lines == ["changing product_versions from [u'RHEL-8.0.0'] to []"]
+      - result.stdout_lines == [changed_message]
 
 - name: query API for product-versions-1 release
   errata_tool_request:

--- a/tests/integration/main.yml.in
+++ b/tests/integration/main.yml.in
@@ -9,5 +9,12 @@
                  | difference([playbook_dir + '/main.yml'])
               }}"
 
+  - name: Get ansible_python_version
+    register: facts
+    setup:
+      filter: ansible_python_version
+    delegate_to: localhost
+    run_once: true
+
   - include: "{{ item }}"
     with_items: "{{ tests }}"


### PR DESCRIPTION
Prior to this PR, the integration tests did not pass on Python 3.

Add conditions for unicode strings on py2 vs py3, and rename the reserved `async` variable name.