### PR TITLE
Remove text_only_advisories_require_dists field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ Errata Tool.
         default_solution: enterprise
         state_machine_rule_set: Default
         move_bugs_on_qe: false
-        text_only_advisories_require_dists: true
 
 
 errata_tool_product_version

--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -96,9 +96,10 @@ options:
      default: false
    text_only_advisories_require_dists:
      description:
-       - Does the product require channels or repos for text-only advisories?
-         For instance many Middleware products have no presence on RHN or RHSM,
-         so set this to false to allow pushes without channels or repos.
+       - DEPRECATED. This field was removed from Errata Tool in ET 4.14.
+         Text only advisories now always require that CDN repos are specified.
+       - For backwards compatibility the field is accepted but its value is
+         ignored. It will be removed entirely in future release of this module.
      choices: [true, false]
      default: true
    exd_org_group:
@@ -284,8 +285,6 @@ def html_form_data(client, params):
     state_machine_rule_set_id = int(rules_scraper.enum[state_machine_rule_set])
     data['product[state_machine_rule_set_id]'] = state_machine_rule_set_id
     data['product[move_bugs_on_qe]'] = int(params['move_bugs_on_qe'])
-    text_only_dists = int(params['text_only_advisories_require_dists'])
-    data['product[text_only_advisories_require_dists]'] = text_only_dists
     exd_org_group = params.get('exd_org_group')
     if exd_org_group is not None:
         exd_org_group_id = int(EXD_ORG_GROUPS[exd_org_group])
@@ -404,6 +403,8 @@ def run_module():
         argument_spec=module_args,
         supports_check_mode=True
     )
+    # Ignore this attribute since it doesn't exist any more in ET
+    del module.params['text_only_advisories_require_dists']
 
     check_mode = module.check_mode
     params = module.params

--- a/tests/integration/errata_tool_product/create-1.yml
+++ b/tests/integration/errata_tool_product/create-1.yml
@@ -25,6 +25,5 @@
     default_solution: enterprise
     state_machine_rule_set: Default
     move_bugs_on_qe: false  # When bugs are added to advisory
-    text_only_advisories_require_dists: true
     exd_org_group: "Middleware & Management"
   register: product

--- a/tests/test_errata_tool_product.py
+++ b/tests/test_errata_tool_product.py
@@ -24,8 +24,7 @@ PRODUCT = {
         "ftp_subdir": "RHCEPH",
         "is_internal": False,
         "isactive": True,
-        "move_bugs_on_qe": False,
-        "text_only_advisories_require_dists": True
+        "move_bugs_on_qe": False
     },
     "relationships": {
         "default_docs_reviewer": {
@@ -137,7 +136,6 @@ class TestGetProduct(object):
             'internal': False,
             'active': True,
             'move_bugs_on_qe': False,
-            'text_only_advisories_require_dists': True,
             'default_docs_reviewer': 'docs-errata-list@redhat.com',
             'default_solution': 'enterprise',
             'push_targets': [


### PR DESCRIPTION
The field was removed from the schema in CWFENGINE-381 because now
all text only advisories should require dists.

Keep it as an acceptible attribute so we don't break existing
playbooks, but ignore its value. It should be considered deprecated.

Issue: #211