### PR TITLE
tests: exercise setting text_only_advisories_require_dists

### DIFF
--- a/tests/integration/errata_tool_product/text-only-dists-1.yml
+++ b/tests/integration/errata_tool_product/text-only-dists-1.yml
@@ -1,0 +1,48 @@
+# Test setting the text_only_advisories_require_dists field.
+#
+# This test case exercises the ability to set the deprecated
+# text_only_advisories_require_dists parameter, so we ensure that existing
+# playbooks will run without crashing.
+#
+# Remove this test when we remove support for
+# text_only_advisories_require_dists entirely.
+---
+
+###########
+
+- name: Create a product with text_only_advisories_require_dists
+  errata_tool_product:
+    short_name: text-only-dists-1
+    name: Testing Text Only Dists
+    description: Testing Text Only Dists
+    default_solution: enterprise
+    state_machine_rule_set: Default
+    push_targets: []
+    # this parameter is deprecated and silently ignored:
+    text_only_advisories_require_dists: true
+  register: result
+
+- name: assert text-only-dists-1 is a new product
+  assert:
+    that:
+      - result.changed
+      - result.stdout_lines == ["created text-only-dists-1 product"]
+
+###########
+
+- name: Alter text_only_advisories_require_dists on existing product
+  errata_tool_product:
+    short_name: text-only-dists-1
+    name: Testing Text Only Dists
+    description: Testing Text Only Dists
+    default_solution: enterprise
+    state_machine_rule_set: Default
+    push_targets: []
+    # this parameter is deprecated and silently ignored:
+    text_only_advisories_require_dists: false
+  register: result
+
+- name: assert errata_tool_product reports no changes
+  assert:
+    that:
+      - not result.changed


### PR DESCRIPTION
This field is deprecated and has no effect, but we want to make sure existing playbooks that define it will continue to work.