### PR TITLE
document default_docs_reviewer and program_manager role requirements

### DIFF
--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -67,6 +67,7 @@ options:
        - The default docs reviewer for advisories. "null" means "Unassigned".
          (Note that once you have changed this value from something other than
          "null", there is no way to change it back to "null".)
+       - This user account must have the "docs" role.
      default: null
    push_targets:
      description:

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -62,6 +62,8 @@ options:
      description:
        - The program manager for this release (login_name, eg
          "coolprogrammanager@redhat.com")
+       - The Errata Tool does not require a specific role for this user
+         account.
      required: false
    blocker_flags:
      description:


### PR DESCRIPTION
The web UI only shows users with the `docs` role in the `default_docs_reviewer` dropdown, so the ET requires that role to be set on these users.

`program_manager` accounts do not require a specific role.