### PR TITLE
tests: use six.PY2 and PY3 in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 from os.path import abspath, dirname, join
+from ansible.module_utils.six import PY2, PY3
 
 
 def pytest_sessionstart(session):
@@ -25,13 +26,13 @@ def pytest_sessionstart(session):
 
     location = join(module_utils_path, 'common_errata_tool.py')
     module_name = "ansible.module_utils.common_errata_tool"
-    if sys.version_info[0] == 3:
+    if PY3:
         # Python 3.5+
         import importlib.util
         spec = importlib.util.spec_from_file_location(module_name, location)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-    if sys.version_info[0] == 2:
+    if PY2:
         import imp
         module = imp.load_source(module_name, location)
     sys.modules[module_name] = module

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import re
-import sys
 import pytest
 import errata_tool_cdn_repo
 from errata_tool_cdn_repo import CDN_RELEASE_TYPES
@@ -15,6 +14,7 @@ from errata_tool_cdn_repo import get_cdn_repo
 from errata_tool_cdn_repo import get_package_tags
 from errata_tool_cdn_repo import normalize_packages
 from errata_tool_cdn_repo import main
+from ansible.module_utils.six import PY2
 from utils import exit_json
 from utils import fail_json
 from utils import set_module_args
@@ -801,7 +801,7 @@ class TestEnsureCdnRepo(object):
             "changing variants from ['8Base-RHCEPH-4.0-Tools'] to"
             " ['8Base-RHCEPH-4.0-Tools', '8Base-RHCEPH-4.1-Tools']"
         ]
-        if sys.version_info.major == 2:
+        if PY2:
             expected_stdout_lines = [
                 "changing variants from [u'8Base-RHCEPH-4.0-Tools'] to"
                 " ['8Base-RHCEPH-4.0-Tools', '8Base-RHCEPH-4.1-Tools']"

--- a/tests/test_errata_tool_user.py
+++ b/tests/test_errata_tool_user.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import sys
 import pytest
 import errata_tool_user
 from errata_tool_user import get_user
@@ -10,6 +9,7 @@ from errata_tool_user import main
 from utils import exit_json
 from utils import set_module_args
 from utils import AnsibleExitJson
+from ansible.module_utils.six import PY2
 
 
 USER = {
@@ -207,7 +207,7 @@ class TestEnsureUser(object):
         check_mode = False
         result = ensure_user(client, params, check_mode)
         expected_stdout_lines = ["changing roles from ['pm'] to ['devel']"]
-        if sys.version_info.major == 2:
+        if PY2:
             expected_stdout_lines = [
                 "changing roles from [u'pm'] to ['devel']"
             ]


### PR DESCRIPTION
Ansible bundles `six`, and the `PY2` and `PY3` constants are easier to understand than parsing `sys` values.