### PR TITLE
tests: rename "exit" variable to "ex"

### DIFF
--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -893,16 +893,16 @@ class TestMain(object):
             'variants': ['8Base-RHCEPH-4.0-Tools', '8Base-RHCEPH-4.1-Tools'],
         }
         set_module_args(module_args)
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True
 
     def test_simple_container(self, container_module_args):
         set_module_args(container_module_args)
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True
 
     @pytest.mark.parametrize('content_type,expected', [
@@ -925,16 +925,16 @@ class TestMain(object):
         container_module_args['content_type'] = 'Docker'
         container_module_args['arch'] = 'x86_64'
         set_module_args(container_module_args)
-        with pytest.raises(AnsibleFailJson) as exit:
+        with pytest.raises(AnsibleFailJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['msg'] == 'arch must be "multi" for Docker repos'
 
     def test_docker_tps_fail(self, container_module_args):
         container_module_args['content_type'] = 'Docker'
         container_module_args['use_for_tps'] = True
         set_module_args(container_module_args)
-        with pytest.raises(AnsibleFailJson) as exit:
+        with pytest.raises(AnsibleFailJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['msg'] == 'do not set "use_for_tps" for Docker repos'

--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -462,9 +462,9 @@ class TestMain(object):
             'product_versions': [],
         }
         set_module_args(module_args)
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True
 
     def test_missing_program_manager(self, monkeypatch):

--- a/tests/test_errata_tool_request.py
+++ b/tests/test_errata_tool_request.py
@@ -32,9 +32,9 @@ class TestMain(object):
             url,
             json={'login_name': 'cooldeveloper@redhat.com'})
         set_module_args({'path': '/api/v1/user/cooldeveloper'})
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True
         assert result['status'] == 200
         assert result['url'] == url
@@ -47,9 +47,9 @@ class TestMain(object):
             url,
             text='<html>new products form</html>')
         set_module_args({'path': '/products/new'})
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True
         assert result['status'] == 200
         assert result['url'] == url
@@ -65,7 +65,7 @@ class TestMain(object):
             'path': '/products/new',
             'return_content': True,
         })
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['content'] == '<html>new products form</html>'

--- a/tests/test_errata_tool_user.py
+++ b/tests/test_errata_tool_user.py
@@ -304,9 +304,9 @@ class TestMain(object):
             'realname': 'Dr. Cool Developer',
         }
         set_module_args(module_args)
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True
         ensure_user_args = mock_ensure_user.call_args[0][1]
         assert ensure_user_args == {

--- a/tests/test_errata_tool_variant.py
+++ b/tests/test_errata_tool_variant.py
@@ -177,7 +177,7 @@ class TestMain(object):
             'product_version': 'RHCEPH-4.0-RHEL-8',
         }
         set_module_args(module_args)
-        with pytest.raises(AnsibleExitJson) as exit:
+        with pytest.raises(AnsibleExitJson) as ex:
             main()
-        result = exit.value.args[0]
+        result = ex.value.args[0]
         assert result['changed'] is True


### PR DESCRIPTION
Don't assign to an `exit` variable, since that's a Python built-in.