### PR TITLE
product: test validate_params() method

### DIFF
--- a/tests/test_errata_tool_product.py
+++ b/tests/test_errata_tool_product.py
@@ -1,6 +1,10 @@
+import pytest
 from errata_tool_product import BUGZILLA_STATES
+from errata_tool_product import InvalidInputError
+from errata_tool_product import validate_params
 from errata_tool_product import get_product
 from errata_tool_product import prepare_diff_data
+from utils import Mock
 
 
 PRODUCT = {
@@ -98,6 +102,40 @@ def test_bugzilla_states():
         'VERIFIED',
     ])
     assert BUGZILLA_STATES == expected
+
+
+class TestValidateParams(object):
+
+    @pytest.mark.parametrize('bugzilla_state', BUGZILLA_STATES)
+    def test_valid_params(self, bugzilla_state):
+        module = Mock()
+        params = {
+            'valid_bug_states': [bugzilla_state],
+            'default_solution': 'enterprise',
+        }
+        validate_params(module, params)
+
+    def test_invalid_bugzilla_states(self):
+        module = Mock()
+        params = {
+            'valid_bug_states': ['NEW', 'BOGUS_STATE_LOL'],
+            'default_solution': 'enterprise',
+        }
+        with pytest.raises(InvalidInputError) as e:
+            validate_params(module, params)
+        assert e.value.param == 'valid_bug_states'
+        assert e.value.value == 'BOGUS_STATE_LOL'
+
+    def test_invalid_solution(self):
+        module = Mock()
+        params = {
+            'valid_bug_states': ['NEW'],
+            'default_solution': 'enterprize lol',
+        }
+        with pytest.raises(InvalidInputError) as e:
+            validate_params(module, params)
+        assert e.value.param == 'default_solution'
+        assert e.value.value == 'ENTERPRIZE LOL'
 
 
 class TestGetProduct(object):


### PR DESCRIPTION
Add unit tests to cover the `validate_params()` method in `errata_tool_product.py`.