### PR TITLE
README: update instructions for RHEL 9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ On RHEL 7::
 
     yum -y install python-requests-gssapi python-lxml
 
-On RHEL 8 and Fedora::
+On RHEL 8+ and Fedora::
 
     yum -y install python3-requests-gssapi python3-lxml
 


### PR DESCRIPTION
Don't hard-code RHEL 8 in the install instructions. These instructions apply to RHEL 9 and beyond.