### PR TITLE
build-collection: fix importing from common_errata_tool

### DIFF
--- a/build-collection
+++ b/build-collection
@@ -20,6 +20,7 @@ cp -r $TOPDIR/module_utils/ plugins/module_utils/
 # Make our common_errata_tool imports compatible with Ansible Collections.
 sed -i \
   -e  's/from ansible.module_utils import common_errata_tool/from ansible_collections.ktdreyer.errata_tool_ansible.plugins.module_utils import common_errata_tool/' \
+  -e  's/from ansible.module_utils.common_errata_tool import /from ansible_collections.ktdreyer.errata_tool_ansible.plugins.module_utils.common_errata_tool import /' \
   plugins/modules/*.py
 
 # Sanity-check that we converted everything:


### PR DESCRIPTION
Prior to this change, Ansible Collections code could not properly import resources directly from `common_errata_tool`.

```
msg: Could not find imported module support code for
ansible_collections.ktdreyer.errata_tool_ansible.plugins.modules.errata_tool_release.
Looked for (['ansible.module_utils.common_errata_tool.UserNotFoundError',
'ansible.module_utils.common_errata_tool'])
```

Update the `sed` command to rewrite these statements appropriately when building the collection package for Ansible Galaxy.