### PR TITLE
github: ignore codecov errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
-        fail_ci_if_error: true
+        fail_ci_if_error: false
 
   test-collection:
     runs-on: ubuntu-latest


### PR DESCRIPTION
codecov has an outage today. Make this upload optional.