### PR TITLE
product: rm unused "module" arg for validate_params()

### DIFF
--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -160,7 +160,7 @@ class DocsReviewerNotFoundError(UserNotFoundError):
     pass
 
 
-def validate_params(module, params):
+def validate_params(params):
     """
     Sanity-check user input for some parameters.
 
@@ -429,7 +429,7 @@ def run_module():
     params = module.params
 
     try:
-        validate_params(module, params)
+        validate_params(params)
     except InvalidInputError as e:
         msg = 'invalid %s value "%s"' % (e.param, e.value)
         module.fail_json(msg=msg, changed=False, rc=1)

--- a/tests/test_errata_tool_product.py
+++ b/tests/test_errata_tool_product.py
@@ -149,32 +149,29 @@ class TestValidateParams(object):
 
     @pytest.mark.parametrize('bugzilla_state', BUGZILLA_STATES)
     def test_valid_params(self, bugzilla_state):
-        module = Mock()
         params = {
             'valid_bug_states': [bugzilla_state],
             'default_solution': 'enterprise',
         }
-        validate_params(module, params)
+        validate_params(params)
 
     def test_invalid_bugzilla_states(self):
-        module = Mock()
         params = {
             'valid_bug_states': ['NEW', 'BOGUS_STATE_LOL'],
             'default_solution': 'enterprise',
         }
         with pytest.raises(InvalidInputError) as e:
-            validate_params(module, params)
+            validate_params(params)
         assert e.value.param == 'valid_bug_states'
         assert e.value.value == 'BOGUS_STATE_LOL'
 
     def test_invalid_solution(self):
-        module = Mock()
         params = {
             'valid_bug_states': ['NEW'],
             'default_solution': 'enterprize lol',
         }
         with pytest.raises(InvalidInputError) as e:
-            validate_params(module, params)
+            validate_params(params)
         assert e.value.param == 'default_solution'
         assert e.value.value == 'ENTERPRIZE LOL'
 


### PR DESCRIPTION
Nothing in `validate_params()` uses the `module` argument. Remove it for simplicity.