### PR TITLE
Use list in exd_org_group

### DIFF
--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -416,7 +416,7 @@ def run_module():
         state_machine_rule_set=dict(required=True),
         move_bugs_on_qe=dict(type='bool', default=False),
         text_only_advisories_require_dists=dict(type='bool', default=True),
-        exd_org_group=dict(choices=EXD_ORG_GROUPS.keys()),
+        exd_org_group=dict(choices=list(EXD_ORG_GROUPS.keys())),
     )
     module = AnsibleModule(
         argument_spec=module_args,


### PR DESCRIPTION
EXD_ORG_GROUPS.keys() is not a list. We need to use list() to convert it to list.
@ktdreyer @simonbaird  Can you help review it? I think it is better to do a test.