### PR TITLE
requirements.txt: pin to Ansible 4 on old python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-ansible
+ansible; python_version>='3.8'
+ansible<5.0; python_version<='3.7'
 lxml
 requests
 requests-gssapi


### PR DESCRIPTION
Ansible 5.0.0 requires Python 3.8. For Python 3.7 and older, pin to the latest Ansible 4 version.