### PR TITLE
add py39 to tox tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         python-version:
         - 2.7
         - 3.6
-        - 3.8
+        - 3.9
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py38, flake8
+envlist = py27, py36, py39, flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Run unit tests with Python 3.9.