### PR TITLE
mergify: remove "delete branch" setting

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,8 +11,3 @@ pull_request_rules:
         strict: true
         strict_method: rebase
         method: rebase
-  - name: delete head branch after merge
-    conditions:
-      - merged
-    actions:
-      delete_head_branch: {}


### PR DESCRIPTION
GitHub does this automatically now, faster than Mergify can do it. Remove this setting to avoid Mergify showing errors when trying to delete non-existent branches.