### PR TITLE
github: add matrix "os" parameter for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on:
       - self-hosted
       - et-integration
+      - '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os: [rhel-7]
     steps:
       - uses: actions/checkout@v1
       - name: Reset ET server database


### PR DESCRIPTION
This commit introduces no functional change. It just re-organizes the settings to make room to add more OSes (eg. rhel-8) in the future.