### PR TITLE
mergify: handle integration test os matrix (rhel-7)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ queue_rules:
     conditions:
       - status-success=tox (2.7)
       - status-success=tox (3.6)
-      - status-success=integration
+      - status-success=integration (rhel-7)
 
 pull_request_rules:
   - name: automatic merge for master when CI passes
@@ -11,7 +11,7 @@ pull_request_rules:
       - author=ktdreyer
       - status-success=tox (2.7)
       - status-success=tox (3.6)
-      - status-success=integration
+      - status-success=integration (rhel-7)
       - base=master
     actions:
       queue:


### PR DESCRIPTION
commit 5478ff0f0e01c04a4e91b66977d2d042a9c66eab renamed the way GitHub reports test results. Update the mergify config to handle this.