### PR TITLE
tests: document exit_json() and fail_json() fakes

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,0 +1,23 @@
+Unit-testing Ansible modules is complicated.
+
+You can test some small methods easily enough, but you will soon want to test
+larger methods, including the ``main()`` method.
+
+Remember, Ansible runs modules on nodes. Each module runs in an individual
+unix process, and it exits with an exit code and a bit of JSON.
+
+For Python Ansible modules (like errata-tool-ansible's modules), we call the
+Ansible APIs ``module.exit_json()`` or ``module.fail_json()`` at the end.
+These methods will effectively quit the Python process, so we need a way to
+handle that in unit tests.
+
+To unit test code that calls ``module.exit_json()`` or ``module.fail_json()``,
+I've written fake methods in ``tests/utils.py``, intended for monkeypatching.
+These fakes will raise with the called values.
+
+* If I expect ``main()`` to exit with a successful exit status, then I use
+  ``with pytest.raises(AnsibleExitJson) as ex:``
+* If I expect ``main()`` to exit with a failure, then I use with
+  ``pytest.raises(AnsibleFailJson) as ex:``
+
+Look at existing unit tests for examples of how to do this.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,12 +38,14 @@ class AnsibleFailJson(Exception):
 
 
 def exit_json(*args, **kwargs):
+    """ Fake AnsibleModule.exit_json(), suitable for monkeypatching """
     if 'changed' not in kwargs:
         kwargs['changed'] = False
     raise AnsibleExitJson(kwargs)
 
 
 def fail_json(*args, **kwargs):
+    """ Fake AnsibleModule.fail_json(), suitable for monkeypatching """
     kwargs['failed'] = True
     raise AnsibleFailJson(kwargs)
 


### PR DESCRIPTION
Document the fake `exit_json()` and `fail_json()` methods in `tests/utils.py`.