### PR TITLE
Fix and improve GitHub Actions tests

### DIFF
--- a/.github/workflows/ansiblegalaxy.yml
+++ b/.github/workflows/ansiblegalaxy.yml
@@ -12,10 +12,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
+    - uses: actions/setup-python@v4
     - name: Install dependencies
       run: |
         # python -m pip install --upgrade pip

--- a/.github/workflows/ansiblegalaxy.yml
+++ b/.github/workflows/ansiblegalaxy.yml
@@ -9,7 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,14 +4,17 @@ on: [push, pull_request]
 
 jobs:
   tox:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
       matrix:
-        python-version:
-        - 2.7
-        - 3.6
-        - 3.9
+        include:
+          - python-version: 2.7
+            os: ubuntu-20.04
+          - python-version: 3.6
+            os: ubuntu-20.04
+          - python-version: 3.9
+            os: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       run: |
         git fetch origin master:master || :
         [ -z $GITHUB_BASE_REF ] || git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - name: Install pandoc
       run: |
         sudo apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
           - python-version: 3.9
             os: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -39,7 +39,7 @@ jobs:
   test-collection:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Fetch base branches for version calculation

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,16 +1,16 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=tox (2.7)
-      - status-success=tox (3.6)
+      - status-success=tox (2.7, ubuntu-20.04)
+      - status-success=tox (3.6, ubuntu-20.04)
       - status-success=integration (rhel-7)
 
 pull_request_rules:
   - name: automatic merge for master when CI passes
     conditions:
       - author=ktdreyer
-      - status-success=tox (2.7)
-      - status-success=tox (3.6)
+      - status-success=tox (2.7, ubuntu-20.04)
+      - status-success=tox (3.6, ubuntu-20.04)
       - status-success=integration (rhel-7)
       - base=master
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ queue_rules:
     conditions:
       - status-success=tox (2.7, ubuntu-20.04)
       - status-success=tox (3.6, ubuntu-20.04)
+      - status-success=tox (3.9, ubuntu-latest)
       - status-success=integration (rhel-7)
 
 pull_request_rules:
@@ -11,6 +12,7 @@ pull_request_rules:
       - author=ktdreyer
       - status-success=tox (2.7, ubuntu-20.04)
       - status-success=tox (3.6, ubuntu-20.04)
+      - status-success=tox (3.9, ubuntu-latest)
       - status-success=integration (rhel-7)
       - base=master
     actions:


### PR DESCRIPTION
The `ubuntu-latest` image no longer has `py27` or `py36` available. Pin to an older Ubuntu image for testing these older Python versions.

Update to the latest `checkout` and `setup-python` actions.

Require `py39` to pass before auto-merging with Mergify.