### PR TITLE
verify users are enabled in strict check mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -340,8 +340,8 @@ If ``ANSIBLE_STRICT_USER_CHECK_MODE`` is ``False`` or unset (default),
 modules will not validate user accounts during check mode.
 
 If ``ANSIBLE_STRICT_USER_CHECK_MODE`` is ``True`` and check mode is on,
-the modules will check the user account and fail if they don't exist
-or don't have required roles.
+the modules will check the user account and fail if they don't exist, are not
+enabled, or lack required roles.
 
 Example of using strict user checking::
 

--- a/library/errata_tool_product.py
+++ b/library/errata_tool_product.py
@@ -463,6 +463,18 @@ def run_module():
             )
             module.fail_json(msg=msg, changed=False, rc=1)
 
+        if not user.get('enabled'):
+            # Note, the ET server does not require the default_docs_reviewer
+            # account to be enabled, but normally a human release engineer
+            # would check that an account is enabled before using it. For ease
+            # of use, we'll raise that error here when
+            # ANSIBLE_STRICT_USER_CHECK_MODE is True.
+            msg = (
+                "default_docs_reviewer %s is not enabled"
+                % params['default_docs_reviewer']
+            )
+            module.fail_json(msg=msg, changed=False, rc=1)
+
     module.exit_json(**result)
 
 

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -449,11 +449,21 @@ def run_module():
         and boolean(os.getenv('ANSIBLE_STRICT_USER_CHECK_MODE', False))
     ):
         try:
-            _ = common_errata_tool.get_user(
-                client, params['program_manager'], True
-            )
+            user = common_errata_tool.get_user(
+                   client, params['program_manager'], True)
         except UserNotFoundError as e:
             msg = 'program_manager %s account not found' % e
+            module.fail_json(msg=msg, changed=False, rc=1)
+        if not user.get('enabled'):
+            # Note, the ET server does not require the program_manager
+            # account to be enabled, but normally a human release engineer
+            # would check that an account is enabled before using it. For ease
+            # of use, we'll raise that error here when
+            # ANSIBLE_STRICT_USER_CHECK_MODE is True.
+            msg = (
+                "program_manager %s is not enabled"
+                % params['program_manager']
+            )
             module.fail_json(msg=msg, changed=False, rc=1)
 
     module.exit_json(**result)

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -450,7 +450,7 @@ def run_module():
     ):
         try:
             user = common_errata_tool.get_user(
-                   client, params['program_manager'], True)
+                client, params['program_manager'], True)
         except UserNotFoundError as e:
             msg = 'program_manager %s account not found' % e
             module.fail_json(msg=msg, changed=False, rc=1)


### PR DESCRIPTION
errata-tool-ansible can configure products and releases with disabled user accounts. This does not always match what a human release engineer would do manually in the web UI.
    
Update `errata_tool_product` and `errata_tool_release` modules to show an error in check mode when the user accounts are not enabled and `ANSIBLE_STRICT_USER_CHECK_MODE` is set.

EDIT: old approach, not used: ~Prior to this change, errata-tool-ansible could configure products and releases with disabled user accounts. Update `common_errata.get_user()` with an additional check to verify that the user account is not disabled.~


See https://issues.redhat.com/browse/CWFCONF-3328 for this feature request.