### PR TITLE
.stickler.yml: max-line-length 120

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   flake8:
     fixer: true
+    max-line-length: 120
     python: 3
 fixers:
   enable: true


### PR DESCRIPTION
It's annoying to coerce lines to be 79 characters. Bump this up a bit.