### PR TITLE
mergify: remove rebase_fallback setting

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,4 +19,3 @@ pull_request_rules:
       queue:
         name: default
         method: rebase
-        rebase_fallback: none


### PR DESCRIPTION
The latest version of Mergify does not allow `rebase_fallback` under the `queue` setting.