### PR TITLE
tests: use_quay_for_containers in integration tests

### DIFF
--- a/tests/integration/errata_tool_product_version/create-2.yml
+++ b/tests/integration/errata_tool_product_version/create-2.yml
@@ -12,8 +12,8 @@
     is_oval_product: true
     allow_buildroot_push: true
     is_server_only: false
-    use_quay_for_containers: false
-    use_quay_for_containers_stage: false
+    use_quay_for_containers: true
+    use_quay_for_containers_stage: true
 
 # We cannot get the name directly yet, CLOUDWF-3
 - name: query API for this product version
@@ -36,8 +36,8 @@
       - attributes.is_oval_product
       - not attributes.is_rhel_addon
       - not attributes.is_server_only
-      - not attributes.use_quay_for_containers
-      - not attributes.use_quay_for_containers_stage
+      - attributes.use_quay_for_containers
+      - attributes.use_quay_for_containers_stage
       - attributes.enabled
 
       - relationships.push_targets == []


### PR DESCRIPTION
Enable the `use_quay_for_containers` settings when creating a new Product Version.