### PR TITLE
product_version: show use_quay_for_containers in task diff

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -279,11 +279,6 @@ def prepare_diff_data(before, after):
         after=after,
         item_name=after['name'],
         item_type='product version',
-        keys_to_copy=[
-            # This field exists in ET but is not yet supported by
-            # this ansible module
-            'use_quay_for_containers',
-        ],
     )
 
 


### PR DESCRIPTION
We fully support the `use_quay_for_containers` parameter now, so we don't need special handling in Ansible's diff output.