### PR TITLE
release: hide is_silent and notify_bugzilla in diff

### DIFF
--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -352,6 +352,10 @@ def prepare_diff_data(before, after):
             'pelc_product_version_name',
             'state_machine_rule_set',
             'zstream_target_release',
+            # https://github.com/ktdreyer/errata-tool-ansible/issues/114
+            'notify_bugzilla_about_release_status',
+            # https://github.com/ktdreyer/errata-tool-ansible/issues/265
+            'is_silent',
         ],
         keys_to_omit=[
             # I think these two are old dead schema that


### PR DESCRIPTION
These fields are unsupported, so we should not display them in a diff.