### PR TITLE
Make errors from Errata Tool API more verbose

### DIFF
--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -305,10 +305,10 @@ def cdn_repo_api_data(params):
 def create_cdn_repo(client, params):
     data = cdn_repo_api_data(params)
     response = client.post('api/v1/cdn_repos', json=data)
-    data = response.json()
     if response.status_code != 201:
-        raise ValueError(data.get('error') or response.text)
+        raise common_errata_tool.ErrataToolError(response)
     name = params['name']
+    data = response.json()
     cdn_repo_data = data['data']
     return get_cdn_repo(client, name, cdn_repo_data=cdn_repo_data)
 
@@ -322,8 +322,7 @@ def edit_cdn_repo(client, cdn_repo_id, differences):
     data = cdn_repo_api_data(params)
     response = client.put('api/v1/cdn_repos/%d' % cdn_repo_id, json=data)
     if response.status_code != 200:
-        errors = response.json()
-        raise ValueError(errors)
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def add_package_tag(client, repo_name, package_name, tag_template, variant):
@@ -346,9 +345,7 @@ def add_package_tag(client, repo_name, package_name, tag_template, variant):
     json = {'cdn_repo_package_tag': json_settings}
     response = client.post(endpoint, json=json)
     if response.status_code != 201:
-        data = response.json()
-        message = 'request: %s, error: %s' % (json, data['error'])
-        raise ValueError(message)
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def edit_package_tag(client, tag_id, desired_tag):
@@ -372,8 +369,7 @@ def edit_package_tag(client, tag_id, desired_tag):
     endpoint = 'api/v1/cdn_repo_package_tags/%d' % tag_id
     response = client.put(endpoint, json=json)
     if response.status_code != 200:
-        data = response.json()
-        raise ValueError(data['error'])
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def delete_package_tag(client, tag_id):
@@ -385,8 +381,7 @@ def delete_package_tag(client, tag_id):
     """
     response = client.delete('api/v1/cdn_repo_package_tags/%d' % tag_id)
     if response.status_code != 204:
-        data = response.json()
-        raise ValueError(data['error'])
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def compare_package_tags(package_name, tag_template, current, desired):

--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -236,12 +236,14 @@ def create_product_version(client, product, params):
     if 'use_quay_for_containers' in params:
         pv['use_quay_for_containers'] = params['use_quay_for_containers']
     if 'use_quay_for_containers_stage' in params:
-        pv['use_quay_for_containers_stage'] = params['use_quay_for_containers_stage']
+        pv['use_quay_for_containers_stage'] = (
+            params['use_quay_for_containers_stage']
+        )
     data = {'product_version': pv}
     endpoint = 'api/v1/products/%s/product_versions' % product
     response = client.post(endpoint, json=data)
     if response.status_code != 201:
-        raise ValueError(response.json())
+        raise common_errata_tool.ErrataToolError(response)
     set_push_targets(client, product, params['name'], params['push_targets'])
 
 
@@ -267,7 +269,7 @@ def edit_product_version(client, product_version, differences):
     endpoint = 'api/v1/products/%s/product_versions/%d' % (product, pv_id)
     response = client.put(endpoint, json=data)
     if response.status_code != 200:
-        raise ValueError(response.json())
+        raise common_errata_tool.ErrataToolError(response)
     if 'push_targets' in pv:
         set_push_targets(client, product, pv_id, pv['push_targets'])
 

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -326,7 +326,7 @@ def create_release(client, params):
     data = api_data(client, params)
     response = client.post('api/v1/releases', json=data)
     if response.status_code != 201:
-        raise ValueError(response.json())
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def edit_release(client, release_id, differences):
@@ -338,7 +338,7 @@ def edit_release(client, release_id, differences):
     data = api_data(client, params)
     response = client.put('api/v1/releases/%d' % release_id, json=data)
     if response.status_code != 200:
-        raise ValueError(response.json())
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def prepare_diff_data(before, after):

--- a/library/errata_tool_user.py
+++ b/library/errata_tool_user.py
@@ -85,11 +85,7 @@ def create_user(client, params):
 
     response = client.post(endpoint, json=params)
     if response.status_code != 201:
-        response_data = response.json()
-        if 'errors' not in response_data:
-            raise ValueError(response_data)
-        errors = response_data['errors']
-        raise ValueError(errors)
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def edit_user(client, user_id, differences):
@@ -108,7 +104,7 @@ def edit_user(client, user_id, differences):
     endpoint = 'api/v1/user/%d' % user_id
     response = client.put(endpoint, json=user)
     if response.status_code != 200:
-        raise ValueError(response.json())
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def ensure_user(client, params, check_mode):

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -128,8 +128,7 @@ def create_variant(client, params):
     data = {'variant': params}
     response = client.post('api/v1/variants', json=data)
     if response.status_code != 201:
-        data = response.json()
-        raise ValueError(data['error'])
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def edit_variant(client, variant_id, differences):
@@ -150,8 +149,7 @@ def edit_variant(client, variant_id, differences):
     response = client.put(endpoint, json=data)
     # TODO: verify 200 is the right code to expect here?
     if response.status_code != 200:
-        data = response.json()
-        raise ValueError(data['error'])
+        raise common_errata_tool.ErrataToolError(response)
 
 
 def prepare_diff_data(before, after):

--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -7,6 +7,20 @@ import requests
 from requests_gssapi import HTTPSPNEGOAuth, DISABLED
 
 
+class ErrataToolError(ValueError):
+    def __init__(self, response):
+        data = response.json()
+        error = data.get('error') or data.get('errors') or response.text
+        msg = 'Unexpected response from Errata Tool: %s' % error
+        request = response.request
+        msg += '\n  Request: %s %s' % (request.method, request.path_url)
+        msg += '\n  Status code: %d' % response.status_code
+        if request.body:
+            msg += '\n  Request body: %s' % request.body.decode('utf-8')
+        super(ErrataToolError, self).__init__(msg)
+        self.response = response
+
+
 class PushTargetScraper(object):
     """
     Scrape the Push Target name-to-id mappings.

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -435,12 +435,12 @@ class TestAddPackageTag(object):
             json={'status': 400, 'error': 'Bad Request'})
         with pytest.raises(ValueError) as err:
             add_package_tag(client, '', '', 'latest', None)
-        request = {'cdn_repo_package_tag':
-                   {'cdn_repo_name': '',
-                    'package_name': '',
-                    'tag_template': 'latest'}}
-        expected = 'request: %s, error: Bad Request' % request
-        assert str(err.value) == expected
+
+        error = str(err.value)
+        assert 'Unexpected response from Errata Tool: Bad Request' in error
+        assert '\n  Request: POST /api/v1/cdn_repo_package_tags' in error
+        assert '\n  Status code: 400' in error
+        assert '\n  Request body: {"cdn_repo_package_tag": {' in error
 
 
 class TestNormalize(object):

--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -220,7 +220,10 @@ class TestCreateRelease(object):
             json={'error': 'Some Error Here'})
         with pytest.raises(ValueError) as err:
             create_release(client, params)
-        assert err.value.args == ({'error': 'Some Error Here'},)
+        error = str(err.value)
+        assert 'Unexpected response from Errata Tool: Some Error Here' in error
+        assert '\n  Request: POST /api/v1/releases' in error
+        assert '\n  Status code: 500' in error
 
     def test_create_async_no_product(self, client, params):
         params['product'] = None
@@ -294,7 +297,15 @@ class TestEditRelease(object):
                         'Red Hat Ceph Storage 4.0 Is Cool')]
         with pytest.raises(ValueError) as err:
             edit_release(client, 1017, differences)
-        assert err.value.args == ({'error': 'Some Error Here'},)
+        error = str(err.value)
+        assert 'Unexpected response from Errata Tool: Some Error Here' in error
+        assert '\n  Request: PUT /api/v1/releases/1017' in error
+        assert '\n  Status code: 500' in error
+        expected_request_body = (
+            '\n  Request body: {"release": {'
+            '"description": "Red Hat Ceph Storage 4.0 Is Cool"}}'
+        )
+        assert expected_request_body in error
 
     def test_state_machine_rule_set(self, client):
         """ Ensure that we send the ID number, not the name. CLOUDWF-298 """


### PR DESCRIPTION
Includes API request details when an unexpected status code is encountered.

Makes error consistent across all API calls.

Also fixes problem when error response from the API contains "errors" field instead of "error" or does not contain any of these.