### PR TITLE
Add role checking for program managers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -364,6 +364,10 @@ And trying to set ``default_docs_reviewer`` without the ``docs`` role::
 
   User nodocsrole does not have 'docs' role in ET
 
+Trying to set ``program_manager`` without these roles ``['pm', 'product-configuration-manager', 'admin']`` also produces an error::
+
+  User nopmroles@redhat.com does not have the following roles in ET: ['pm', 'product-configuration-manager', 'admin']
+
 File paths
 ----------
 

--- a/library/errata_tool_release.py
+++ b/library/errata_tool_release.py
@@ -70,7 +70,8 @@ options:
          with the web UI, or the errata_tool_user Ansible module, or some
          other method.
        - The Errata Tool does not require a specific role for this user
-         account.
+         account but in order to actually manage releases they must have
+         the following roles: ['pm', 'product-configuration-manager', 'admin'].
      required: false
    blocker_flags:
      description:
@@ -459,6 +460,15 @@ def run_module():
         except UserNotFoundError as e:
             msg = 'program_manager %s account not found' % e
             module.fail_json(msg=msg, changed=False, rc=1)
+
+        pm_roles = ['pm', 'product-configuration-manager', 'admin']
+        if not any(role in pm_roles for role in user['roles']):
+            msg = (
+                "User %s does not have the following roles in ET: %s"
+                % (params['program_manager'], pm_roles)
+            )
+            module.fail_json(msg=msg, changed=False, rc=1)
+
         if not user.get('enabled'):
             # Note, the ET server does not require the program_manager
             # account to be enabled, but normally a human release engineer


### PR DESCRIPTION
Adds role checking for program_managers. 

The roles referenced for managing releases can be found here:
https://code.engineering.redhat.com/gerrit/plugins/gitiles/errata-rails/+/refs/heads/master/app/models/concerns/user_permissions.rb#49

JIRA: CWFCONF-4580