### PR TITLE
github: drop py27 matrix entry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,6 @@ jobs:
       max-parallel: 5
       matrix:
         include:
-          - python-version: 2.7
-            os: ubuntu-20.04
           - python-version: 3.6
             os: ubuntu-20.04
           - python-version: 3.9


### PR DESCRIPTION
GitHub no longer supports running Python 2.7 natively.