### PR TITLE
tests: re-add use_quay_for_containers parameters

### DIFF
--- a/tests/integration/errata_tool_product_version/create-2.yml
+++ b/tests/integration/errata_tool_product_version/create-2.yml
@@ -12,6 +12,9 @@
     is_oval_product: true
     allow_buildroot_push: true
     is_server_only: false
+    # no-ops, just testing for backwards compatibility with older playbooks:
+    use_quay_for_containers: true
+    use_quay_for_containers_stage: true
 
 # We cannot get the name directly yet, CLOUDWF-3
 - name: query API for this product version


### PR DESCRIPTION
Re-add the parameters we dropped from the integration tests in https://github.com/ktdreyer/errata-tool-ansible/pull/291. 

These are no-ops now, but this test ensures that we will not crash when older playbooks specify these parameters.