### PR TITLE
Fix showing diffs for lists

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -292,7 +292,8 @@ def run_module():
 
     client = common_errata_tool.Client()
 
-    # 'use_quay_for_containers' and 'use_quay_for_containers_stage' are deprecated.
+    # 'use_quay_for_containers' and 'use_quay_for_containers_stage' are
+    # deprecated.
     params.pop('use_quay_for_containers')
     params.pop('use_quay_for_containers_stage')
 

--- a/module_utils/common_errata_tool.py
+++ b/module_utils/common_errata_tool.py
@@ -178,6 +178,15 @@ def task_diff_data(before, after, item_name, item_type,
             if key in before and key not in after:
                 del before[key]
 
+        # Normalize lists (remove duplicates and sort)
+        for keys in (before, after):
+            for key, value in keys.items():
+                if isinstance(value, list):
+                    try:
+                        keys[key] = sorted(set(value))
+                    except TypeError:
+                        pass  # skip for unhashable types
+
     return {
         'before': before,
         'after': after,

--- a/tests/test_errata_tool_product.py
+++ b/tests/test_errata_tool_product.py
@@ -271,6 +271,37 @@ class TestPrepareDiffData(object):
 
         assert prepare_diff_data(before_data, after_data) == expected_output
 
+    def test_diff_data_consistent_lists(self):
+        before_data = {
+            'id': 123,
+            'short_name': 'RHDIFF',
+            'description': 'foo',
+            'push_targets': ['ftp', 'cdn', 'cdn_stage'],
+        }
+
+        after_data = {
+            'short_name': 'RHDIFF',
+            'description': 'bar',
+            'push_targets': ['ftp', 'cdn_stage', 'cdn'],
+        }
+
+        expected_output = {
+            'before': {
+                'short_name': 'RHDIFF',
+                'description': 'foo',
+                'push_targets': ['cdn', 'cdn_stage', 'ftp'],
+            },
+            'after': {
+                'short_name': 'RHDIFF',
+                'description': 'bar',
+                'push_targets': ['cdn', 'cdn_stage', 'ftp'],
+            },
+            'before_header': "Original product 'RHDIFF'",
+            'after_header': "Modified product 'RHDIFF'",
+        }
+
+        assert prepare_diff_data(before_data, after_data) == expected_output
+
 
 class TestEnsureProduct(object):
 

--- a/tests/test_errata_tool_release.py
+++ b/tests/test_errata_tool_release.py
@@ -212,17 +212,18 @@ class TestCreateRelease(object):
         assert history[-1].method == 'POST'
         assert history[-1].json() == expected
 
-    @pytest.mark.parametrize('response', [
-        {'json': {'error': 'Some Error Here'}},
-        {'text': 'Some Error Here'},
+    @pytest.mark.parametrize('response_text,response_json', [
+        (None, {'error': 'Some Error Here'}),
+        ('Some Error Here', None),
     ])
-    def test_error(self, client, params, response):
+    def test_error(self, client, params, response_text, response_json):
         """ Ensure that we raise any server message to the user. """
         client.adapter.register_uri(
             'POST',
             PROD + '/api/v1/releases',
             status_code=500,
-            **response,
+            text=response_text,
+            json=response_json,
         )
         with pytest.raises(ValueError) as err:
             create_release(client, params)


### PR DESCRIPTION
Avoids showing confusing diffs for lists/arrays. For example:

    --- before: Original product 'Test-product'
    +++ after: Modified product 'Test-product'
    @@ -1,24 +1,22 @@
    ...
    push_targets:
    - ftp
    +- cdn
    - cdn_stage
    -- cdn
    short_name: Test-product
    ...

This assumes that all list attributes do not depend on item order and cannot contain duplicate items.