### PR TITLE
ima_sig_key fixes

### DIFF
--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -211,7 +211,8 @@ def create_product_version(client, product, params):
     pv['brew_tags'] = params['brew_tags']
     pv['rhel_release_name'] = params['rhel_release_name']
     pv['sig_key_name'] = params['sig_key_name']
-    pv['ima_sig_key_name'] = params.get('ima_sig_key_name')
+    if 'ima_sig_key_name' in params:
+        pv['ima_sig_key_name'] = params['ima_sig_key_name']
     pv['allow_buildroot_push'] = params['allow_buildroot_push']
     pv['push_targets'] = params['push_targets']
     data = {'product_version': pv}

--- a/library/errata_tool_product_version.py
+++ b/library/errata_tool_product_version.py
@@ -286,7 +286,7 @@ def run_module():
         description=dict(required=True),
         rhel_release_name=dict(required=True),
         sig_key_name=dict(default='redhatrelease2'),
-        ima_sig_key_name=dict(type='str'),
+        ima_sig_key_name=dict(),
         default_brew_tag=dict(required=True),
         is_server_only=dict(type='bool', required=True),
         enabled=dict(type='bool', default=True),

--- a/tests/integration/errata_tool_cdn_repo/packages-1.yml
+++ b/tests/integration/errata_tool_cdn_repo/packages-1.yml
@@ -47,6 +47,7 @@
   # Assign this variable here in order to use the !unsafe data type to handle
   # "{{" and "}}" braces in the string.
   set_fact:
+    removing_version_prerelease_advisory: !unsafe 'removing "{{version}}-prerelease-{{advisory}}" tag template from "test-container"'
     removing_version_release: !unsafe 'removing "{{version}}-{{release}}" tag template from "test-container"'
     removing_version_hotfix_advisory: !unsafe 'removing "{{version}}-{{hotfix}}-{{advisory}}" tag template from "test-container"'
 
@@ -54,11 +55,12 @@
   assert:
     that:
       - result.changed
-      - result.stdout_lines | length == 4
+      - result.stdout_lines | length == 5
       - result.stdout_lines.0 == "changing package_names from [] to ['test-container']"
-      - result.stdout_lines.1 == removing_version_release
-      - result.stdout_lines.2 == removing_version_hotfix_advisory
-      - result.stdout_lines.3 == "adding \"latest\" tag template to \"test-container\""
+      - result.stdout_lines.1 == removing_version_prerelease_advisory
+      - result.stdout_lines.2 == removing_version_release
+      - result.stdout_lines.3 == removing_version_hotfix_advisory
+      - result.stdout_lines.4 == "adding \"latest\" tag template to \"test-container\""
 
 # Assert that this CDN repo looks correct.
 

--- a/tests/integration/errata_tool_product_version/ima-sig-key-1.yml
+++ b/tests/integration/errata_tool_product_version/ima-sig-key-1.yml
@@ -1,0 +1,39 @@
+# Test setting the ima_sig_key_name field on a new PV.
+#
+---
+
+- name: Add IMA-1 Product Version with a ima_sig_key_name
+  errata_tool_product_version:
+    product: RHEL
+    name: RHEL-IMA-1
+    description: Red Hat IMA1 Product Version
+    default_brew_tag: rhel-8.0.0-candidate
+    rhel_release_name: RHEL-8.0.0
+    push_targets: []
+    is_rhel_addon: false
+    brew_tags: [rhel-8.0.0-candidate]
+    allow_rhn_debuginfo: true
+    is_oval_product: true
+    allow_buildroot_push: true
+    is_server_only: false
+    ima_sig_key_name: redhatimarelease
+  register: ima_key_1
+
+- name: assert result for creating PV
+  assert:
+    that:
+      - ima_key_1.changed
+
+# We cannot get the name directly yet, CLOUDWF-3
+- name: query API for this product version
+  errata_tool_request:
+    path: api/v1/products/RHEL/product_versions/?filter[name]=RHEL-IMA-1
+  register: response
+
+- name: parse product version JSON
+  set_fact:
+    relationships: "{{ response.json.data.0.relationships }}"
+
+- assert:
+    that:
+      - relationships.ima_sig_key.name == 'redhatimarelease'

--- a/tests/integration/errata_tool_product_version/ima-sig-key-2.yml
+++ b/tests/integration/errata_tool_product_version/ima-sig-key-2.yml
@@ -1,0 +1,77 @@
+# Test setting the ima_sig_key_name field on an existing PV where none was set
+# previously.
+#
+---
+
+- name: Add IMA-2 Product Version with no ima_sig_key_name
+  errata_tool_product_version:
+    product: RHEL
+    name: RHEL-IMA-2
+    description: Red Hat IMA2 Product Version
+    default_brew_tag: rhel-8.0.0-candidate
+    rhel_release_name: RHEL-8.0.0
+    push_targets: []
+    is_rhel_addon: false
+    brew_tags: [rhel-8.0.0-candidate]
+    allow_rhn_debuginfo: true
+    is_oval_product: true
+    allow_buildroot_push: true
+    is_server_only: false
+  register: ima_key_2
+
+- name: assert result for creating PV
+  assert:
+    that:
+      - ima_key_2.changed
+
+# We cannot get the name directly yet, CLOUDWF-3
+- name: query API for this product version
+  errata_tool_request:
+    path: api/v1/products/RHEL/product_versions/?filter[name]=RHEL-IMA-2
+  register: response
+
+- name: parse product version JSON
+  set_fact:
+    relationships: "{{ response.json.data.0.relationships }}"
+
+- assert:
+    that:
+      - "'ima_sig_key' not in relationships.keys()"
+
+#################
+
+- name: Add ima_sig_key_name to IMA-2 Product Version
+  errata_tool_product_version:
+    product: RHEL
+    name: RHEL-IMA-2
+    description: Red Hat IMA2 Product Version
+    default_brew_tag: rhel-8.0.0-candidate
+    rhel_release_name: RHEL-8.0.0
+    push_targets: []
+    is_rhel_addon: false
+    brew_tags: [rhel-8.0.0-candidate]
+    allow_rhn_debuginfo: true
+    is_oval_product: true
+    allow_buildroot_push: true
+    is_server_only: false
+    ima_sig_key_name: redhatimarelease
+  register: ima_key_2
+
+- name: assert PV changed
+  assert:
+    that:
+      - ima_key_2.changed
+
+# We cannot get the name directly yet, CLOUDWF-3
+- name: query API for this product version
+  errata_tool_request:
+    path: api/v1/products/RHEL/product_versions/?filter[name]=RHEL-IMA-2
+  register: response
+
+- name: parse product version JSON
+  set_fact:
+    relationships: "{{ response.json.data.0.relationships }}"
+
+- assert:
+    that:
+      - relationships.ima_sig_key.name == 'redhatimarelease'

--- a/tests/test_errata_tool_product_version.py
+++ b/tests/test_errata_tool_product_version.py
@@ -250,7 +250,7 @@ class TestEnsureProductVersion(object):
         assert history[1].method == 'POST'
         assert history[1].url == \
             'https://errata.devel.redhat.com/api/v1/products/RHCEPH/product_versions'
-        assert history[1].json()['product_version']['ima_sig_key_name'] is None
+        assert 'ima_sig_key_name' not in history[1].json()['product_version']
 
 
 class TestFormErrors(object):


### PR DESCRIPTION
A couple of fixes for the CI, and a followup to https://github.com/ktdreyer/errata-tool-ansible/pull/309:

1. Fix the integration tests to handle the addition of `prerelease-{{advisory}}` to `DEFAULT_TAG_TEMPLATES` from CWFCONF-5454.

2. Remove `type='str'` from the module's argument_spec, since this is Ansible's default behavior already.

3. When creating a new Product Version without `ima_sig_key_name`, don't send any `ima_sig_key_name` value to the server. (This fixes a crash in the integration tests. For some reason the server responded with a HTTP 500 error.)

4. Add new integration tests for setting `ima_sig_key_name` on new and existing Product Versions.

