### PR TITLE
mergify: remove py27 requirement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=tox (2.7, ubuntu-20.04)
       - status-success=tox (3.6, ubuntu-20.04)
       - status-success=tox (3.9, ubuntu-latest)
       - status-success=integration (rhel-7)
@@ -12,7 +11,6 @@ pull_request_rules:
       - or:
         - author=ktdreyer
         - author=hluk
-      - status-success=tox (2.7, ubuntu-20.04)
       - status-success=tox (3.6, ubuntu-20.04)
       - status-success=tox (3.9, ubuntu-latest)
       - status-success=integration (rhel-7)


### PR DESCRIPTION
I've dropped the py27 tests in GitHub Actions in https://github.com/ktdreyer/errata-tool-ansible/pull/287