### PR TITLE
integration test fixes (drop el7, new docker repo names)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Reset ET server database
         run: |
           pushd /home/cloud-user/errata-rails
-          sudo -E docker-compose exec -T dev /code/bin/rake db:reset db:fixtures:load > /dev/null
+          sudo -E docker-compose exec -T dev rake db:reset db:fixtures:load > /dev/null
           popd
       - name: Run integration tests
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - rhel-7
           - rhel-8
     steps:
       - uses: actions/checkout@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ queue_rules:
     conditions:
       - status-success=tox (3.6, ubuntu-20.04)
       - status-success=tox (3.9, ubuntu-latest)
-      - status-success=integration (rhel-7)
       - status-success=integration (rhel-8)
 
 pull_request_rules:
@@ -14,7 +13,6 @@ pull_request_rules:
         - author=hluk
       - status-success=tox (3.6, ubuntu-20.04)
       - status-success=tox (3.9, ubuntu-latest)
-      - status-success=integration (rhel-7)
       - status-success=integration (rhel-8)
       - base=master
     actions:

--- a/README.rst
+++ b/README.rst
@@ -148,9 +148,9 @@ Errata Tool.
 
 .. code-block:: yaml
 
-    - name: Add redhat-rhceph-rhceph-4-rhel8 cdn repo
+    - name: Add rhceph/rhceph-4-rhel8 cdn repo
       errata_tool_cdn_repo:
-        name: redhat-rhceph-rhceph-4-rhel8
+        name: rhceph/rhceph-4-rhel8
         external_name: rhceph/rhceph-4-rhel8
         release_type: Primary
         content_type: Docker

--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -93,8 +93,7 @@ EXAMPLES = '''
 
   - name: Add rhceph-4-tools-for-rhel-8-x86_64-rpms cdn repo
     errata_tool_cdn_repo:
-      name: redhat-rhceph-rhceph-4-rhel8
-      external_name: rhceph/rhceph-4-rhel8
+      name: rhceph-4-tools-for-rhel-8-x86_64-rpms
       release_type: Primary
       content_type: Binary
       use_for_tps: True

--- a/library/errata_tool_cdn_repo.py
+++ b/library/errata_tool_cdn_repo.py
@@ -22,8 +22,8 @@ description:
 options:
    name:
      description:
-       - Pulp repo label.
-       - "Example: redhat-rhceph-rhceph-4-rhel8"
+       - Public repo name
+       - "Example: rhceph/rhceph-4-rhel8"
      required: true
    external_name:
      description:
@@ -112,9 +112,9 @@ EXAMPLES = '''
       variants:
         - RHEL-8-RHOCS-4.6
 
-  - name: Add redhat-rhceph-rhceph-4-rhel8 cdn repo
+  - name: Add rhceph/rhceph-4-rhel8 cdn repo
     errata_tool_cdn_repo:
-      name: redhat-rhceph-rhceph-4-rhel8
+      name: rhceph/rhceph-4-rhel8
       external_name: rhceph/rhceph-4-rhel8
       release_type: Primary
       content_type: Docker
@@ -129,7 +129,7 @@ EXAMPLES = '''
 
   - name: Add a repo with a restricted tag
     errata_tool_cdn_repo:
-      name: redhat-fooproduct-1-rhel8
+      name: fooproduct/foo-1-rhel8
       release_type: Primary
       content_type: Docker
       variants:
@@ -143,7 +143,7 @@ EXAMPLES = '''
 
   - name: Add a repo with a tag for hotfix
     errata_tool_cdn_repo:
-      name: redhat-fooproduct-1-rhel8
+      name: fooproduct/foo-1-rhel8
       release_type: Primary
       content_type: Docker
       variants:
@@ -157,7 +157,7 @@ EXAMPLES = '''
 
   - name: Add a repo with a tag for prerelease
     errata_tool_cdn_repo:
-      name: redhat-fooproduct-1-rhel8
+      name: fooproduct/foo-1-rhel8
       release_type: Primary
       content_type: Docker
       variants:
@@ -263,7 +263,7 @@ def get_package_tags(client, name):
     """
     # We will query all the packages' tags for this repo.
     # Example for looking up one single package in one single repo:
-    # https://errata.devel.redhat.com/api/v1/cdn_repo_package_tags?filter[package_name]=ubi8-container&filter[cdn_repo_name]=redhat-ubi8
+    # https://errata.devel.redhat.com/api/v1/cdn_repo_package_tags?filter[package_name]=ubi8-container&filter[cdn_repo_name]=ubi8
     page_number = 0
     elements = []
     found = []

--- a/tests/integration/errata_tool_cdn_repo/create-2.yml
+++ b/tests/integration/errata_tool_cdn_repo/create-2.yml
@@ -4,9 +4,9 @@
 # errata-rails.git test/fixtures/*.yml files do this.
 ---
 
-- name: Add redhat-container-create-2 cdn repo
+- name: Add testproduct/container-create-2 cdn repo
   errata_tool_cdn_repo:
-    name: redhat-container-create-2
+    name: testproduct/container-create-2
     release_type: Primary
     content_type: Docker
     variants:
@@ -21,7 +21,7 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-create-2
+    path: api/v1/cdn_repos/testproduct/container-create-2
   register: response
 
 - name: parse cdn repo JSON
@@ -31,7 +31,7 @@
 
 - assert:
     that:
-      - attributes.name == "redhat-container-create-2"
+      - attributes.name == "testproduct/container-create-2"
       - attributes.release_type == "Primary"
       - attributes.content_type == "Docker"
       - not attributes.use_for_tps

--- a/tests/integration/errata_tool_cdn_repo/packages-1.yml
+++ b/tests/integration/errata_tool_cdn_repo/packages-1.yml
@@ -6,23 +6,23 @@
 
 - name: Create cdn repo with no packages
   errata_tool_cdn_repo:
-    name: redhat-container-packages-1
+    name: testproduct/container-packages-1
     release_type: Primary
     content_type: Docker
     variants: [AppStream-8.0.0]
   register: result
 
-- name: assert redhat-container-packages-1 is a new cdn repo
+- name: assert testproduct/container-packages-1 is a new cdn repo
   assert:
     that:
       - result.changed
-      - result.stdout_lines == ["created redhat-container-packages-1"]
+      - result.stdout_lines == ["created testproduct/container-packages-1"]
 
 # Assert that this CDN repo looks correct.
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-packages-1
+    path: api/v1/cdn_repos/testproduct/container-packages-1
   register: response
 
 - name: assert new cdn repo has no packages
@@ -34,7 +34,7 @@
 
 - name: Add a container package to an existing CDN repo with no packages
   errata_tool_cdn_repo:
-    name: redhat-container-packages-1
+    name: testproduct/container-packages-1
     release_type: Primary
     content_type: Docker
     variants: [AppStream-8.0.0]
@@ -68,7 +68,7 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-packages-1
+    path: api/v1/cdn_repos/testproduct/container-packages-1
   register: response
 
 - name: assert CDN repo has our new container package
@@ -81,7 +81,7 @@
 
 - name: Add a variant restriction to container tag
   errata_tool_cdn_repo:
-    name: redhat-container-packages-1
+    name: testproduct/container-packages-1
     release_type: Primary
     content_type: Docker
     variants: [AppStream-8.0.0]
@@ -101,7 +101,7 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-packages-1
+    path: api/v1/cdn_repos/testproduct/container-packages-1
   register: response
 
 - name: assert CDN repo still has our one container package
@@ -112,7 +112,7 @@
 
 - name: query API for this CDN repo's package tags
   errata_tool_request:
-    path: api/v1/cdn_repo_package_tags/?filter[cdn_repo_name]=redhat-container-packages-1&filter[package_name]=test-container
+    path: api/v1/cdn_repo_package_tags/?filter[cdn_repo_name]=testproduct/container-packages-1&filter[package_name]=test-container
   register: response
 
 - name: assert latest tag has variant restriction
@@ -126,7 +126,7 @@
 
 - name: Remove a variant restriction from container tag
   errata_tool_cdn_repo:
-    name: redhat-container-packages-1
+    name: testproduct/container-packages-1
     release_type: Primary
     content_type: Docker
     variants: [AppStream-8.0.0]
@@ -145,7 +145,7 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-packages-1
+    path: api/v1/cdn_repos/testproduct/container-packages-1
   register: response
 
 - name: assert CDN repo still has our one container package
@@ -156,7 +156,7 @@
 
 - name: query API for this CDN repo's package tags
   errata_tool_request:
-    path: api/v1/cdn_repo_package_tags/?filter[cdn_repo_name]=redhat-container-packages-1&filter[package_name]=test-container
+    path: api/v1/cdn_repo_package_tags/?filter[cdn_repo_name]=testproduct/container-packages-1&filter[package_name]=test-container
   register: response
 
 - name: assert latest tag exists and has no variant restriction
@@ -170,7 +170,7 @@
 
 - name: Remove all container packages from an existing CDN repo
   errata_tool_cdn_repo:
-    name: redhat-container-packages-1
+    name: testproduct/container-packages-1
     release_type: Primary
     content_type: Docker
     variants: [AppStream-8.0.0]
@@ -197,7 +197,7 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-packages-1
+    path: api/v1/cdn_repos/testproduct/container-packages-1
   register: response
 
 - name: assert CDN repo has no container packages

--- a/tests/integration/errata_tool_cdn_repo/variants-1.yml
+++ b/tests/integration/errata_tool_cdn_repo/variants-1.yml
@@ -31,27 +31,27 @@
 
 - name: Create cdn repo with one variant
   errata_tool_cdn_repo:
-    name: redhat-container-variants-1
+    name: testproduct/container-variants-1
     release_type: Primary
     content_type: Docker
     variants:
       - AppStream-8.0.0
   register: result
 
-- name: assert redhat-container-variants-1 is a new cdn repo
+- name: assert testproduct/container-variants-1 is a new cdn repo
   assert:
     that:
       - result.changed
-      - result.stdout_lines == ["created redhat-container-variants-1"]
+      - result.stdout_lines == ["created testproduct/container-variants-1"]
 
 # Assert that this CDN repo looks correct.
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-variants-1
+    path: api/v1/cdn_repos/testproduct/container-variants-1
   register: response
 
-- name: assert redhat-container-variants-1 has one variant
+- name: assert testproduct/container-variants-1 has one variant
   assert:
     that:
       - response.json.data.relationships.variants | length == 1
@@ -61,7 +61,7 @@
 
 - name: Add a second variant to existing cdn repo
   errata_tool_cdn_repo:
-    name: redhat-container-variants-1
+    name: testproduct/container-variants-1
     release_type: Primary
     content_type: Docker
     variants:
@@ -89,10 +89,10 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-variants-1
+    path: api/v1/cdn_repos/testproduct/container-variants-1
   register: response
 
-- name: assert redhat-container-variants-1 now has two variants
+- name: assert testproduct/container-variants-1 now has two variants
   assert:
     that:
       - response.json.data.relationships.variants | length == 2
@@ -107,7 +107,7 @@
 
 - name: Remove the second variant from an existing cdn repo
   errata_tool_cdn_repo:
-    name: redhat-container-variants-1
+    name: testproduct/container-variants-1
     release_type: Primary
     content_type: Docker
     variants:
@@ -134,10 +134,10 @@
 
 - name: query API for this CDN repo
   errata_tool_request:
-    path: api/v1/cdn_repos/redhat-container-variants-1
+    path: api/v1/cdn_repos/testproduct/container-variants-1
   register: response
 
-- name: assert redhat-container-variants-1 now has one variant
+- name: assert testproduct/container-variants-1 now has one variant
   assert:
     that:
       - response.json.data.relationships.variants | length == 1

--- a/tests/test_errata_tool_cdn_repo.py
+++ b/tests/test_errata_tool_cdn_repo.py
@@ -25,13 +25,13 @@ from utils import Mock
 
 PROD = 'https://errata.devel.redhat.com'
 
-# From /api/v1/cdn_repos/?filter[name]=redhat-rhceph-rhceph-4-rhel8
+# From /api/v1/cdn_repos/?filter[name]=rhceph/rhceph-4-rhel8
 # See CLOUDWF-316
 CDN_REPO = {
     "id": 11010,
     "type": "cdn_repos",
     "attributes": {
-        "name": "redhat-rhceph-rhceph-4-rhel8",
+        "name": "rhceph/rhceph-4-rhel8",
         "external_name": "rhceph/rhceph-4-rhel8",
         "release_type": "Primary",
         "use_for_tps": False,
@@ -80,7 +80,7 @@ CDN_REPO = {
 }
 
 # From
-# /api/v1/cdn_repo_package_tags?filter[cdn_repo_name]=redhat-rhceph-rhceph-4-rhel8
+# /api/v1/cdn_repo_package_tags?filter[cdn_repo_name]=rhceph/rhceph-4-rhel8
 CDN_REPO_PACKAGE_TAGS = [
     {
         "id": 13860,
@@ -93,7 +93,7 @@ CDN_REPO_PACKAGE_TAGS = [
         "relationships": {
             "cdn_repo": {
                 "id": 11010,
-                "name": "redhat-rhceph-rhceph-4-rhel8"
+                "name": "rhceph/rhceph-4-rhel8"
             },
             "package": {
                 "id": 45969,
@@ -112,7 +112,7 @@ CDN_REPO_PACKAGE_TAGS = [
         "relationships": {
             "cdn_repo": {
                 "id": 11010,
-                "name": "redhat-rhceph-rhceph-4-rhel8"
+                "name": "rhceph/rhceph-4-rhel8"
             },
             "package": {
                 "id": 45969,
@@ -131,7 +131,7 @@ CDN_REPO_PACKAGE_TAGS = [
         "relationships": {
             "cdn_repo": {
                 "id": 11010,
-                "name": "redhat-rhceph-rhceph-4-rhel8"
+                "name": "rhceph/rhceph-4-rhel8"
             },
             "package": {
                 "id": 45969,
@@ -150,7 +150,7 @@ CDN_REPO_PACKAGE_TAGS = [
         "relationships": {
             "cdn_repo": {
                 "id": 11010,
-                "name": "redhat-rhceph-rhceph-4-rhel8"
+                "name": "rhceph/rhceph-4-rhel8"
             },
             "package": {
                 "id": 45969,
@@ -173,7 +173,7 @@ CDN_REPO_PACKAGE_TAGS = [
         "relationships": {
             "cdn_repo": {
                 "id": 11010,
-                "name": "redhat-rhceph-rhceph-4-rhel8"
+                "name": "rhceph/rhceph-4-rhel8"
             },
             "package": {
                 "id": 45969,
@@ -192,7 +192,7 @@ CDN_REPO_PACKAGE_TAGS = [
         "relationships": {
             "cdn_repo": {
                 "id": 11010,
-                "name": "redhat-rhceph-rhceph-4-rhel8"
+                "name": "rhceph/rhceph-4-rhel8"
             },
             "package": {
                 "id": 45969,
@@ -252,7 +252,7 @@ class TestCreateCdnRepo(object):
             status_code=201,
             json={'data': CDN_REPO})
         params = {
-            'name': 'redhat-rhceph-rhceph-4-rhel8',
+            'name': 'rhceph/rhceph-4-rhel8',
             'external_name': 'rhceph/rhceph-4-rhel8',
             'release_type': 'Primary',
             'content_type': 'Docker',
@@ -265,7 +265,7 @@ class TestCreateCdnRepo(object):
         assert len(history) == 1
         expected = {
             'cdn_repo': {
-                'name': 'redhat-rhceph-rhceph-4-rhel8',
+                'name': 'rhceph/rhceph-4-rhel8',
                 'external_name': 'rhceph/rhceph-4-rhel8',
                 'release_type': 'Primary',
                 'content_type': 'Docker',
@@ -359,7 +359,7 @@ class TestGetCdnRepo(object):
             'GET',
             PROD + '/api/v1/cdn_repos',
             json={'data': []})
-        name = 'redhat-rhceph-rhceph-4-rhel8'
+        name = 'rhceph/rhceph-4-rhel8'
         cdn_repo = get_cdn_repo(client, name)
         assert cdn_repo is None
 
@@ -368,11 +368,11 @@ class TestGetCdnRepo(object):
             'GET',
             PROD + '/api/v1/cdn_repos',
             json={'data': [CDN_REPO]})
-        name = 'redhat-rhceph-rhceph-4-rhel8'
+        name = 'rhceph/rhceph-4-rhel8'
         cdn_repo = get_cdn_repo(client, name)
         expected = {
             'id': 11010,
-            'name': 'redhat-rhceph-rhceph-4-rhel8',
+            'name': 'rhceph/rhceph-4-rhel8',
             'external_name': 'rhceph/rhceph-4-rhel8',
             'release_type': 'Primary',
             'use_for_tps': False,
@@ -395,11 +395,11 @@ class TestGetCdnRepo(object):
             'GET',
             PROD + '/api/v1/cdn_repos',
             json={'data': [cdn_repo]})
-        name = 'redhat-rhceph-rhceph-4-rhel8'
+        name = 'rhceph/rhceph-4-rhel8'
         cdn_repo = get_cdn_repo(client, name)
         expected = {
             'id': 11010,
-            'name': 'redhat-rhceph-rhceph-4-rhel8',
+            'name': 'rhceph/rhceph-4-rhel8',
             'external_name': 'rhceph/rhceph-4-rhel8',
             'release_type': 'Primary',
             'use_for_tps': False,
@@ -421,7 +421,7 @@ class TestGetPackageTags(object):
             'GET',
             PROD + '/api/v1/cdn_repo_package_tags',
             json={'data': CDN_REPO_PACKAGE_TAGS})
-        name = 'redhat-rhceph-rhceph-4-rhel8'
+        name = 'rhceph/rhceph-4-rhel8'
         cdn_repo = get_package_tags(client, name)
         expected = {
             'rhceph-container': {
@@ -473,7 +473,7 @@ class TestAddPackageTag(object):
 
     @pytest.fixture
     def repo_name(self):
-        return 'redhat-rhceph-rhceph-4-rhel8'
+        return 'rhceph/rhceph-4-rhel8'
 
     @pytest.fixture
     def package_name(self):
@@ -489,7 +489,7 @@ class TestAddPackageTag(object):
         history = client.adapter.request_history
         assert len(history) == 1
         expected = {'cdn_repo_package_tag':
-                    {'cdn_repo_name': 'redhat-rhceph-rhceph-4-rhel8',
+                    {'cdn_repo_name': 'rhceph/rhceph-4-rhel8',
                      'package_name': 'rhceph-container',
                      'tag_template': 'latest'}}
         assert history[0].json() == expected
@@ -504,7 +504,7 @@ class TestAddPackageTag(object):
         history = client.adapter.request_history
         assert len(history) == 1
         expected = {'cdn_repo_package_tag':
-                    {'cdn_repo_name': 'redhat-rhceph-rhceph-4-rhel8',
+                    {'cdn_repo_name': 'rhceph/rhceph-4-rhel8',
                      'package_name': 'rhceph-container',
                      'tag_template': 'restricted-tag',
                      'variant_name': 'Product-Foo'}}
@@ -520,7 +520,7 @@ class TestAddPackageTag(object):
         history = client.adapter.request_history
         assert len(history) == 1
         expected = {'cdn_repo_package_tag':
-                    {'cdn_repo_name': 'redhat-rhceph-rhceph-4-rhel8',
+                    {'cdn_repo_name': 'rhceph/rhceph-4-rhel8',
                      'package_name': 'rhceph-container',
                      'tag_template': 'hotfix-tag',
                      'for_hotfix': True}}
@@ -536,7 +536,7 @@ class TestAddPackageTag(object):
         history = client.adapter.request_history
         assert len(history) == 1
         expected = {'cdn_repo_package_tag':
-                    {'cdn_repo_name': 'redhat-rhceph-rhceph-4-rhel8',
+                    {'cdn_repo_name': 'rhceph/rhceph-4-rhel8',
                      'package_name': 'rhceph-container',
                      'tag_template': 'prerelease-tag',
                      'for_prerelease': True}}
@@ -611,7 +611,7 @@ class EnsurePackageTagsBase(object):
                 },
                 'relationships': {
                     'cdn_repo': {'id': 11010,
-                                 'name': 'redhat-rhceph-rhceph-4-rhel8'},
+                                 'name': 'rhceph/rhceph-4-rhel8'},
                     'package': {'id': 45969, 'name': 'rhceph-container'},
                 }
                 }
@@ -638,7 +638,7 @@ class EnsurePackageTagsBase(object):
 
     @pytest.fixture
     def name(self):
-        return 'redhat-rhceph-rhceph-4-rhel8'
+        return 'rhceph/rhceph-4-rhel8'
 
 
 class TestEnsurePackageTags(EnsurePackageTagsBase):
@@ -953,7 +953,7 @@ class TestEnsureCdnRepo(object):
     @pytest.fixture
     def params(self):
         return {
-            'name': 'redhat-rhceph-rhceph-4-rhel8',
+            'name': 'rhceph/rhceph-4-rhel8',
             'external_name': 'rhceph/rhceph-4-rhel8',
             'release_type': 'Primary',
             'content_type': 'Docker',
@@ -995,11 +995,11 @@ class TestEnsureCdnRepo(object):
         result = ensure_cdn_repo(client, check_mode, params)
         expected = {
             'changed': True,
-            'stdout_lines': ['created redhat-rhceph-rhceph-4-rhel8'],
+            'stdout_lines': ['created rhceph/rhceph-4-rhel8'],
             'diff': {
                 'after': {'arch': 'multi',
                           'content_type': 'Docker',
-                          'name': 'redhat-rhceph-rhceph-4-rhel8',
+                          'name': 'rhceph/rhceph-4-rhel8',
                           'external_name': 'rhceph/rhceph-4-rhel8',
                           'packages': {
                               'rhceph-container': [
@@ -1018,7 +1018,7 @@ class TestEnsureCdnRepo(object):
                           'use_for_tps': False,
                           'variants': ['8Base-RHCEPH-4.0-Tools',
                                        '8Base-RHCEPH-4.1-Tools']},
-                'after_header': "New cdn repo 'redhat-rhceph-rhceph-4-rhel8'",
+                'after_header': "New cdn repo 'rhceph/rhceph-4-rhel8'",
                 'before': {},
                 'before_header': 'Not present'}}
 
@@ -1048,7 +1048,7 @@ class TestEnsureCdnRepo(object):
             "relationships": {
                 "cdn_repo": {
                     "id": 11010,
-                    "name": "redhat-rhceph-rhceph-4-rhel8"
+                    "name": "rhceph/rhceph-4-rhel8"
                 },
                 "package": {"id": 45969, "name": "rhceph-container"}
             }
@@ -1064,7 +1064,7 @@ class TestEnsureCdnRepo(object):
         check_mode = False
         result = ensure_cdn_repo(client, check_mode, params)
         expected_stdout_lines = [
-            'created redhat-rhceph-rhceph-4-rhel8',
+            'created rhceph/rhceph-4-rhel8',
             'adding "{{version}}" tag template to "rhceph-container"',
             ('adding "my-variant-restricted-tag" tag template'
              ' to "rhceph-container"'),
@@ -1164,7 +1164,7 @@ class TestMain(object):
     @pytest.fixture
     def container_module_args(self):
         return {
-            'name': 'redhat-rhceph-rhceph-4-rhel8',
+            'name': 'rhceph/rhceph-4-rhel8',
             'external_name': 'rhceph/rhceph-4-rhel8',
             'release_type': 'Primary',
             'content_type': 'Docker',


### PR DESCRIPTION
- I can't get `docker-compose` to work on RHEL 7, and the ET developers  prefer `podman-compose` (RHELWF-10345).
- The path to `rake` has changed in newer ET versions. Update the GH Action for this.
- We can't use Pulp-style repo names any more (#320)

Fixes: #320 