### PR TITLE
removed requiring tps steam logic from variant creation step

### DIFF
--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -225,6 +225,8 @@ def run_module():
 
     if params['rhel_variant'] is None:
         params.pop('rhel_variant')
+    if params['tps_stream'] is None:
+        params.pop('tps_stream')
 
     client = common_errata_tool.Client()
 

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -56,12 +56,13 @@ options:
        - If you omit a rhel_variant setting, the Errata Tool will assume you
          are configuring RHEL itself, and it will mark this variant as a RHEL
          variant.
-       - When you omit rhel_variant, you must define tps_stream.
      required: false
    tps_stream:
      description:
-       - Required for base (RHEL) variants which do not have a rhel_variant.
-       - "example: RHEL-7"
+       - DEPRECATED. This is now optional and has no effect. It was previously
+         required for base (RHEL) variants which do not have a rhel_variant.
+         Now tps_stream is auto retrieved from rhsm-pulp and stored in Errata Tool's
+         CDN repo table instead.
      required: false
    push_targets:
      description:
@@ -225,8 +226,8 @@ def run_module():
 
     if params['rhel_variant'] is None:
         params.pop('rhel_variant')
-    if params['tps_stream'] is None:
-        params.pop('tps_stream')
+    # Drop the deprecated tps_stream field for Variant, it is now ignored by Errata Tool
+    params.pop('tps_stream', None)
 
     client = common_errata_tool.Client()
 

--- a/library/errata_tool_variant.py
+++ b/library/errata_tool_variant.py
@@ -223,15 +223,8 @@ def run_module():
     check_mode = module.check_mode
     params = module.params
 
-    # When a user omits rhel_variant, then this is a RHEL variant and we
-    # require tps_stream.
     if params['rhel_variant'] is None:
         params.pop('rhel_variant')
-        if params['tps_stream'] is None:
-            module.fail_json(msg='RHEL variants require tps_stream.')
-    else:
-        # This is a layered product and we ignore tps_stream.
-        params.pop('tps_stream')
 
     client = common_errata_tool.Client()
 


### PR DESCRIPTION
The tps stream field or determining tps stream for a variant is deprecated once https://issues.redhat.com/browse/RHELWF-8494 is merged. So this mandatory require TPS stream for variant logic is not applicable.